### PR TITLE
Add in support for elementaryOS

### DIFF
--- a/deb/setup
+++ b/deb/setup
@@ -33,6 +33,12 @@ if [ "x$DISTRO" == "xmaya" ]; then
     DISTRO="precise"
 fi
 
+if [ "x$DISTRO" == "luna" ]; then
+    echo "You seem to be using elementaryOS version $DISTRO."
+    echo "This maps to Ubuntu trusty... adjusting for you..."
+    DISTRO="trusty"
+fi
+
 if [ -f "/etc/apt/sources.list.d/chris-lea-node_js-$DISTRO.list" ]; then
     echo -n "Removing Launchpad PPA Repository for NodeJS... "
     add-apt-repository -y -r ppa:chris-lea/node.js


### PR DESCRIPTION
ElementaryOS uses the same core and packages as Ubuntu 14.04 but has a different name (like Mint).  Updated script to check for this name (luna) and if so then switch to trusty.
