### PR TITLE
Docker test script for ubuntu & debian

### DIFF
--- a/test/test-docker.sh
+++ b/test/test-docker.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+TARGETS="            \
+  ubuntu:10.04       \
+  ubuntu:12.04       \
+  ubuntu:14.04       \
+  debian:stable      \
+  debian:testing     \
+  debian:unstable    \
+"
+
+CMD="                                                   \
+     apt-get update && apt-get install curl -y          \
+  && curl -sL https://deb.nodesource.com/setup | bash - \
+  && apt-get install nodejs build-essential python -y          \
+  && curl -sL https://deb.nodesource.com/test | bash -  \
+"
+
+for target in $TARGETS; do
+
+  outfile="/tmp/node-dist-test-docker-${target}.out"
+
+  echo -e "\033[1m\033[33m## Testing ${target}, writing output to ${outfile} ...\033[39m\033[22m"
+
+  docker run -t --rm $target /bin/bash -c "$CMD" > $outfile
+
+  if [ $? == 0 ]; then
+    echo -e "\033[1m\033[32m## Test of ${target} SUCCESSFUL\033[39m\033[22m"
+  else
+    echo -e "\033[1m\033[31m## Test of ${target} FAILED\033[39m\033[22m"
+  fi
+
+  echo ""
+
+done


### PR DESCRIPTION
Tests all 3 Ubuntu LTS releases and the 3 supported Debian releases. Sets up a container, runs the install script, runs the test script and exits (with cleanup). Output is put to files in /tmp but status is printed to stdout so it's easy to see what's failing.

Should be expanded to other distros that we support and are available in Docker Hub.

/cc @wblankenship 
