### PR TITLE
Ensures aptitude cache is populated before running lsb-release

### DIFF
--- a/deb/setup
+++ b/deb/setup
@@ -12,7 +12,7 @@
 # wget -qO- https://deb.nodesource.com/setup | bash -
 #
 
-export DEBIAN_FRONTEND=noninteractive 
+export DEBIAN_FRONTEND=noninteractive
 
 print_status() {
     echo
@@ -51,9 +51,12 @@ if [ ! -x /usr/bin/curl ] && [ ! -x /usr/bin/wget ]; then
     PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} curl"
 fi
 
+# Populating Cache
+print_status "Populating apt-get cache..."
+exec_cmd 'apt-get update'
+
 if [ "X${PRE_INSTALL_PKGS}" != "X" ]; then
     print_status "Installing packages required for setup:${PRE_INSTALL_PKGS}..."
-    exec_cmd 'apt-get update'
     # This next command needs to be redirected to /dev/null or the script will bork
     # in some environments
     exec_cmd "apt-get install -y${PRE_INSTALL_PKGS} 2>&1 > /dev/null"


### PR DESCRIPTION
Justification:

```
$ lsb_release -c -s
jessie
$ rm -rf /var/lib/apt/lists/*
$ lsb_release -c -s
n/a
$ apt-get update
...
Reading package lists... Done
$ lsb_release -c -s
jessie
```
