### PR TITLE
Added proxy support.

### DIFF
--- a/rpm/setup
+++ b/rpm/setup
@@ -34,6 +34,13 @@ exec_cmd() {
   exec_cmd_nobail "$1" || bail
 }
 
+if [[ -n "$http_proxy" ]]; then
+  HTTP_PROXY_STRING="http_proxy=$http_proxy"
+fi
+
+if [[ -n "$https_proxy" ]]; then
+  HTTPS_PROXY_STRING="https_proxy=$https_proxy"
+fi
 
 print_status "Inspecting system..."
 
@@ -136,7 +143,7 @@ print_status "Confirming \"${DIST_TYPE}${DIST_VERSION}-${DIST_ARCH}\" is support
 
 ## Simple fetch & fast-fail to see if the nodesource-release
 ## file exists for this distro/version/arch
-exec_cmd_nobail "curl -sLf -o /dev/null '${RELEASE_URL}'"
+exec_cmd_nobail "$HTTP_PROXY_STRING $HTTPS_PROXY_STRING curl -sLf -o /dev/null '${RELEASE_URL}'"
 RC=$?
 
 if [[ $RC != 0 ]]; then
@@ -163,8 +170,8 @@ if [ "$DIST_TYPE" == "el" ] && [ "$DIST_VERSION" == "5" ]; then
     ## We can scrape the html to find the latest epel-release (likely 5.4)
     epel_url="http://dl.fedoraproject.org/pub/epel/5/${DIST_ARCH}/"
     epel_release_view="${epel_url}repoview/epel-release.html"
-    echo "+ curl -s $epel_release_view | grep -oE 'epel-release-[0-9\-]+\.noarch\.rpm'"
-    epel=$(curl -s $epel_release_view | grep -oE 'epel-release-[0-9\-]+\.noarch\.rpm')
+    echo "+ $HTTP_PROXY_STRING $HTTPS_PROXY_STRING curl -s $epel_release_view | grep -oE 'epel-release-[0-9\-]+\.noarch\.rpm'"
+    epel=$($HTTP_PROXY_STRING $HTTPS_PROXY_STRING curl -s $epel_release_view | grep -oE 'epel-release-[0-9\-]+\.noarch\.rpm')
     if [ "X${epel}" = "X" ]; then
       print_status "Error: Could not find current EPEL release RPM!"
       exit 1
@@ -193,7 +200,7 @@ print_status "Downloading release setup RPM..."
 echo "+ mktemp"
 RPM_TMP=$(mktemp || bail)
 
-exec_cmd "curl -sL -o '${RPM_TMP}' '${RELEASE_URL}'"
+exec_cmd "$HTTP_PROXY_STRING $HTTPS_PROXY_STRING curl -sL -o '${RPM_TMP}' '${RELEASE_URL}'"
 
 print_status "Installing release setup RPM..."
 


### PR DESCRIPTION
I am not proud of this bit.  I was going to make a comment on how to use it, but then I think I am just going to leave it like this and let the powers that be decide what if anything to do with it.

I am behind a proxy and installing using the documented method fails.  I don't export $http_proxy or $https_proxy usually as I am often using curl/wget for internal methods that don't require a proxy.

So the way I use it now works like the following:

```
https_proxy=http://some.proxy.org:8080 curl -sL https://rpm.nodesource.com/setup | \
sudo https_proxy=http://some.proxy.org:8080 bash -
```

If you don't have any proxy variables set, it shouldn't affect operation.  It's ugly, but I can't immediately think of a clean way to pass the first $https_proxy through the pipe and sudo.
