### PR TITLE
No longer need to install nodejs-legacy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ curl -sL https://deb.nodesource.com/setup | bash -
 Then install with **Debian** (as root):
 
 ```text
-apt-get install -y nodejs nodejs-legacy
+apt-get install -y nodejs
 ```
 
 ***Optional***: install build tools


### PR DESCRIPTION
We now conflict nodejs-legacy, so installing our package will "do the right thing" by itself now.