### PR TITLE
Backward compatibility with RHEL5.1

### DIFF
--- a/rpm/setup
+++ b/rpm/setup
@@ -156,6 +156,10 @@ if [ "$DIST_TYPE" == "el" ] && [ "$DIST_VERSION" == "5" ]; then
 
   echo "+ yum repolist enabled 2> /dev/null | grep epel"
   repolist=$(yum repolist enabled 2> /dev/null | grep epel)
+  if [ "X${repolist}" == "X" ]; then
+    echo "+ yum --disablerepo='*' --enablerepo='epel' list available 2> /dev/null | grep epel"
+    repolist=$(yum --disablerepo='*' --enablerepo='epel' list available 2> /dev/null | grep epel)
+  fi
 
   if [ "X${repolist}" == "X" ]; then
     print_status "Finding current EPEL release RPM..."


### PR DESCRIPTION
RHEL5.1's yum command does not understand "repolist" command.
A possible work around is to disable all repos and try to enable "epel" only and check available packages.