### PR TITLE
Change a-z regex to [:alpha:] in the rpm setup

### DIFF
--- a/rpm/setup
+++ b/rpm/setup
@@ -101,7 +101,7 @@ else
 
   ## Using the redhat-release-server-X, centos-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[a-z]+-release(-server|-workstation)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation)?-([0-9]+).*$/\2/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 


### PR DESCRIPTION
It seems that `sed` uses current locale for character collation when doing regexes. It happens that in my locale (Estonian) the leter "z" is positioned right after "s" in the alphabet, so the setup script always fails as "centos" is not mathced for `[a-z]+` ("t" comes after "z" in the alphabet). If I use `[[:alpha:]]` instead of `[a-z]` the script succeeds.

Distro: centos-release-6-6.el6.centos.12.2.x86_64
Locale: Estonian