### PR TITLE
Installation on LinuxMint with Chris Lea PPA crashes

### DIFF
--- a/deb/setup
+++ b/deb/setup
@@ -110,7 +110,7 @@ fi
 if [ -f "/etc/apt/sources.list.d/chris-lea-node_js-$DISTRO.list" ]; then
     print_status 'Removing Launchpad PPA Repository for NodeJS...'
 
-    exec_cmd 'add-apt-repository -y -r ppa:chris-lea/node.js'
+    if [ $(lsb_release -i -s) != "LinuxMint" ]; then exec_cmd 'add-apt-repository -y -r ppa:chris-lea/node.js'; fi
     exec_cmd "rm -f /etc/apt/sources.list.d/chris-lea-node_js-${DISTRO}.list"
 fi
 


### PR DESCRIPTION
Linux Mint does not provide the option to remove a ppa: https://github.com/linuxmint/mintsources/issues/15 So script crashes on line 113 if you previously installed this PPA.
Just added a check for Mint distribution. Alone command `rm -f /etc/apt/sources.list.d/chris-lea-node_js-${DISTRO}.list` should works well.