### PR TITLE
new setup scripts for new repo locations

### DIFF
--- a/deb/setup
+++ b/deb/setup
@@ -3,7 +3,8 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install NodeSource repo onto a Debian or Ubuntu system.
+# Script to install the NodeSource Node.js 0.10 repo onto a
+# Debian or Ubuntu system.
 #
 # Run as root or insert `sudo` before `bash`:
 #
@@ -33,6 +34,10 @@ exec_cmd_nobail() {
 exec_cmd() {
     exec_cmd_nobail "$1" || bail
 }
+
+
+print_status "Installing the NodeSource Node.js 0.10 repo..."
+
 
 PRE_INSTALL_PKGS=""
 
@@ -95,10 +100,10 @@ fi
 print_status "Confirming \"${DISTRO}\" is supported..."
 
 if [ -x /usr/bin/curl ]; then
-    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/node/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/node010/dists/${DISTRO}/Release'"
     RC=$?
 else
-    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/node/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/node010/dists/${DISTRO}/Release'"
     RC=$?
 fi
 
@@ -122,10 +127,10 @@ else
     exec_cmd 'wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -'
 fi
 
-print_status 'Creating apt sources list file for the NodeSource repo...'
+print_status 'Creating apt sources list file for the NodeSource Node.js 0.10 repo...'
 
-exec_cmd "echo 'deb https://deb.nodesource.com/node ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
-exec_cmd "echo 'deb-src https://deb.nodesource.com/node ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb https://deb.nodesource.com/node010 ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb-src https://deb.nodesource.com/node010 ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
 
 print_status 'Running `apt-get update` for you...'
 

--- a/deb/setup
+++ b/deb/setup
@@ -136,4 +136,4 @@ print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-print_status 'Run `apt-get install nodejs` (as root) to install Node.js and npm'
+print_status 'Run `apt-get install nodejs` (as root) to install Node.js 0.10 and npm'

--- a/deb/setup_0.10
+++ b/deb/setup_0.10
@@ -3,14 +3,14 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js 0.12 repo onto a
+# Script to install the NodeSource Node.js 0.10 repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo` before `bash`:
 #
-# curl -sL https://deb.nodesource.com/setup_dev | bash -
+# curl -sL https://deb.nodesource.com/setup_0.10 | bash -
 #   or
-# wget -qO- https://deb.nodesource.com/setup_dev | bash -
+# wget -qO- https://deb.nodesource.com/setup_0.10 | bash -
 #
 
 export DEBIAN_FRONTEND=noninteractive
@@ -36,7 +36,7 @@ exec_cmd() {
 }
 
 
-print_status "Installing the NodeSource Node.js 0.12 repo..."
+print_status "Installing the NodeSource Node.js 0.10 repo..."
 
 
 PRE_INSTALL_PKGS=""
@@ -100,10 +100,10 @@ fi
 print_status "Confirming \"${DISTRO}\" is supported..."
 
 if [ -x /usr/bin/curl ]; then
-    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/node012/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/node010/dists/${DISTRO}/Release'"
     RC=$?
 else
-    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/node012/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/node010/dists/${DISTRO}/Release'"
     RC=$?
 fi
 
@@ -127,10 +127,10 @@ else
     exec_cmd 'wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -'
 fi
 
-print_status 'Creating apt sources list file for the NodeSource Node.js 0.12 repo...'
+print_status 'Creating apt sources list file for the NodeSource Node.js 0.10 repo...'
 
-exec_cmd "echo 'deb https://deb.nodesource.com/node012 ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
-exec_cmd "echo 'deb-src https://deb.nodesource.com/node012 ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb https://deb.nodesource.com/node010 ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb-src https://deb.nodesource.com/node010 ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
 
 print_status 'Running `apt-get update` for you...'
 

--- a/deb/setup_0.10
+++ b/deb/setup_0.10
@@ -136,4 +136,4 @@ print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-print_status 'Run `apt-get install nodejs` (as root) to install Node.js and npm'
+print_status 'Run `apt-get install nodejs` (as root) to install Node.js 0.10 and npm'

--- a/deb/setup_0.12
+++ b/deb/setup_0.12
@@ -8,9 +8,9 @@
 #
 # Run as root or insert `sudo` before `bash`:
 #
-# curl -sL https://deb.nodesource.com/setup_dev | bash -
+# curl -sL https://deb.nodesource.com/setup_0.12 | bash -
 #   or
-# wget -qO- https://deb.nodesource.com/setup_dev | bash -
+# wget -qO- https://deb.nodesource.com/setup_0.12 | bash -
 #
 
 export DEBIAN_FRONTEND=noninteractive

--- a/deb/setup_dev
+++ b/deb/setup_dev
@@ -136,4 +136,4 @@ print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-print_status 'Run `apt-get install nodejs` (as root) to install Node.js and npm'
+print_status 'Run `apt-get install nodejs` (as root) to install Node.js 0.12 and npm'

--- a/deb/setup_iojs_1.x
+++ b/deb/setup_iojs_1.x
@@ -3,14 +3,14 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js 0.12 repo onto a
+# Script to install the NodeSource io.js 1.x repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo` before `bash`:
 #
-# curl -sL https://deb.nodesource.com/setup_0.12 | bash -
+# curl -sL https://deb.nodesource.com/setup_iojs_1.x | bash -
 #   or
-# wget -qO- https://deb.nodesource.com/setup_0.12 | bash -
+# wget -qO- https://deb.nodesource.com/setup_iojs_1.x | bash -
 #
 
 export DEBIAN_FRONTEND=noninteractive
@@ -36,7 +36,7 @@ exec_cmd() {
 }
 
 
-print_status "Installing the NodeSource Node.js 0.12 repo..."
+print_status "Installing the NodeSource io.js 1.x repo..."
 
 
 PRE_INSTALL_PKGS=""
@@ -100,10 +100,10 @@ fi
 print_status "Confirming \"${DISTRO}\" is supported..."
 
 if [ -x /usr/bin/curl ]; then
-    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/node012/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/iojs_1.x/dists/${DISTRO}/Release'"
     RC=$?
 else
-    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/node012/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/iojs_1.x/dists/${DISTRO}/Release'"
     RC=$?
 fi
 
@@ -127,13 +127,13 @@ else
     exec_cmd 'wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -'
 fi
 
-print_status 'Creating apt sources list file for the NodeSource Node.js 0.12 repo...'
+print_status 'Creating apt sources list file for the NodeSource io.js 1.x repo...'
 
-exec_cmd "echo 'deb https://deb.nodesource.com/node012 ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
-exec_cmd "echo 'deb-src https://deb.nodesource.com/node012 ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb https://deb.nodesource.com/iojs_1.x ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb-src https://deb.nodesource.com/iojs_1.x ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
 
 print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-print_status 'Run `apt-get install nodejs` (as root) to install Node.js 0.12 and npm'
+print_status 'Run `apt-get install iojs` (as root) to install io.js 1.x and npm'

--- a/deb/src/_setup.sh
+++ b/deb/src/_setup.sh
@@ -100,10 +100,10 @@ fi
 print_status "Confirming \"${DISTRO}\" is supported..."
 
 if [ -x /usr/bin/curl ]; then
-    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/node{{repo}}/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/{{repo}}/dists/${DISTRO}/Release'"
     RC=$?
 else
-    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/node{{repo}}/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/{{repo}}/dists/${DISTRO}/Release'"
     RC=$?
 fi
 
@@ -129,11 +129,11 @@ fi
 
 print_status 'Creating apt sources list file for the NodeSource {{name}} repo...'
 
-exec_cmd "echo 'deb https://deb.nodesource.com/node{{repo}} ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
-exec_cmd "echo 'deb-src https://deb.nodesource.com/node{{repo}} ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb https://deb.nodesource.com/{{repo}} ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb-src https://deb.nodesource.com/{{repo}} ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
 
 print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-print_status 'Run `apt-get install nodejs` (as root) to install Node.js and npm'
+print_status 'Run `apt-get install {{package}}` (as root) to install {{name}} and npm'

--- a/deb/src/_setup.sh
+++ b/deb/src/_setup.sh
@@ -3,14 +3,14 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js 0.12 repo onto a
+# Script to install the NodeSource {{name}} repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo` before `bash`:
 #
-# curl -sL https://deb.nodesource.com/setup_dev | bash -
+# curl -sL https://deb.nodesource.com/setup{{suffix}} | bash -
 #   or
-# wget -qO- https://deb.nodesource.com/setup_dev | bash -
+# wget -qO- https://deb.nodesource.com/setup{{suffix}} | bash -
 #
 
 export DEBIAN_FRONTEND=noninteractive
@@ -36,7 +36,7 @@ exec_cmd() {
 }
 
 
-print_status "Installing the NodeSource Node.js 0.12 repo..."
+print_status "Installing the NodeSource {{name}} repo..."
 
 
 PRE_INSTALL_PKGS=""
@@ -100,10 +100,10 @@ fi
 print_status "Confirming \"${DISTRO}\" is supported..."
 
 if [ -x /usr/bin/curl ]; then
-    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/node012/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/node{{repo}}/dists/${DISTRO}/Release'"
     RC=$?
 else
-    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/node012/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/node{{repo}}/dists/${DISTRO}/Release'"
     RC=$?
 fi
 
@@ -127,10 +127,10 @@ else
     exec_cmd 'wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -'
 fi
 
-print_status 'Creating apt sources list file for the NodeSource Node.js 0.12 repo...'
+print_status 'Creating apt sources list file for the NodeSource {{name}} repo...'
 
-exec_cmd "echo 'deb https://deb.nodesource.com/node012 ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
-exec_cmd "echo 'deb-src https://deb.nodesource.com/node012 ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb https://deb.nodesource.com/node{{repo}} ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb-src https://deb.nodesource.com/node{{repo}} ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
 
 print_status 'Running `apt-get update` for you...'
 

--- a/deb/src/build.sh
+++ b/deb/src/build.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
-RELEASES=( "010::Node.js 0.10"
-           "010:_0.10:Node.js 0.10"
-           "012:_0.12:Node.js 0.12"
-           "012:_dev:Node.js 0.12"
+RELEASES=( "node010::nodejs:Node.js 0.10"
+           "node010:_0.10:nodejs:Node.js 0.10"
+           "node012:_0.12:nodejs:Node.js 0.12"
+           "node012:_dev:nodejs:Node.js 0.12"
+	   "iojs_1.x:_iojs_1.x:iojs:io.js 1.x"
          )
 SOURCE=_setup.sh
 DEST=../setup
@@ -11,8 +12,9 @@ DEST=../setup
 for release in "${RELEASES[@]}"; do
     repo=${release%%:*}
     suffix=$(echo $release | cut -d: -f2)
-    name=$(echo $release | cut -d: -f3)
+    package=$(echo $release | cut -d: -f3)
+    name=$(echo $release | cut -d: -f4)
     cat $SOURCE \
-      | sed 's/{{repo}}/'"$repo"'/g;s/{{suffix}}/'"$suffix"'/g;s/{{name}}/'"$name"'/g' \
+      | sed 's/{{repo}}/'"$repo"'/g;s/{{suffix}}/'"$suffix"'/g;s/{{name}}/'"$name"'/g;s/{{package}}/'"$package"'/g' \
       > ${DEST}${suffix}
 done

--- a/deb/src/build.sh
+++ b/deb/src/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+RELEASES=( "010::Node.js 0.10"
+           "010:_0.10:Node.js 0.10"
+           "012:_0.12:Node.js 0.12"
+           "012:_dev:Node.js 0.12"
+         )
+SOURCE=_setup.sh
+DEST=../setup
+
+for release in "${RELEASES[@]}"; do
+    repo=${release%%:*}
+    suffix=$(echo $release | cut -d: -f2)
+    name=$(echo $release | cut -d: -f3)
+    cat $SOURCE \
+      | sed 's/{{repo}}/'"$repo"'/g;s/{{suffix}}/'"$suffix"'/g;s/{{name}}/'"$name"'/g' \
+      > ${DEST}${suffix}
+done

--- a/rpm/test.sh
+++ b/rpm/test.sh
@@ -71,6 +71,7 @@ testCheckDistro  cloudlinux-release-6-6.6.0.x86_64                 x86_64  el   
 testCheckDistro  centos-release-6-6.6.0.x86_64                     x86_64  el       6           x86_64   https://rpm.nodesource.com/pub/el/6/x86_64/nodesource-release-el6-1.noarch.rpm
 
 testCheckDistro  redhat-release-5Server-5.10.0.4                   x86_64  el       5           x86_64   https://rpm.nodesource.com/pub/el/5/x86_64/nodesource-release-el5-1.noarch.rpm
+testCheckDistro  redhat-release-5Server-5.5.0.2                    x86_64  el       5           x86_64   https://rpm.nodesource.com/pub/el/5/x86_64/nodesource-release-el5-1.noarch.rpm
 testCheckDistro  redhat-release-server-6Server-6.5.0.1.el6.x86_64  x86_64  el       6           x86_64   https://rpm.nodesource.com/pub/el/6/x86_64/nodesource-release-el6-1.noarch.rpm
 testCheckDistro  redhat-release-server-7.0-1.el7.x86_64            x86_64  el       7           x86_64   https://rpm.nodesource.com/pub/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
 testCheckDistro  redhat-release-workstation-6Workstation-6.5.0.2.el6.x86_64 x86_64 el 6         x86_64   https://rpm.nodesource.com/pub/el/6/x86_64/nodesource-release-el6-1.noarch.rpm


### PR DESCRIPTION
adds a deb/src/ directory with a `build.sh` script that takes `_setup.sh` and creates a bunch of `setup*` scripts to be pushed to deb.nodesource.com pointing to the new repo locations:

* `setup` -> https://deb.nodesource.com/node010 (legacy script name support)
* `setup_dev` -> https://deb.nodesource.com/node012 (legacy script name support, we can push them on to 0.13 if it appears)
* `setup_0.10` -> https://deb.nodesource.com/node010
* `setup_0.12` -> https://deb.nodesource.com/node012

I'm also imaging:

* `setup_iojs` - follow the latest io.js release, no matter what version (less dramatic upgrades)
* `setup_iojs_1.6` - if, for example, 1.6.\* becomes an LTS release branch for io.js we set up a script just for tracking patch releases on that.
