### PR TITLE
No -r flag for add-apt-repository in Linux Mint

### DIFF
--- a/deb/setup
+++ b/deb/setup
@@ -110,7 +110,7 @@ fi
 if [ -f "/etc/apt/sources.list.d/chris-lea-node_js-$DISTRO.list" ]; then
     print_status 'Removing Launchpad PPA Repository for NodeJS...'
 
-    exec_cmd 'add-apt-repository -y -r ppa:chris-lea/node.js'
+    exec_cmd_nobail 'add-apt-repository -y -r ppa:chris-lea/node.js'
     exec_cmd "rm -f /etc/apt/sources.list.d/chris-lea-node_js-${DISTRO}.list"
 fi
 


### PR DESCRIPTION
The add-apt-repository command in Linux Mint 17 Qiana does not
support the -r flag. Therefore, do not fail on that command, since
the following command will take care of removing the PPA anyway.