### PR TITLE
update supported distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,18 @@ NodeSource will maintain Ubuntu distributions in active support by Canonical, in
 
 NodeSource will maintain support for stable, testing and unstable releases of Debian, due to the long release cycle a considerable number of users are running unstable.
 
-* **Debian 7 / stable** (wheezy)
-* **Debian testing** (jessie)
+* **Debian 7** (wheezy)
+* **Debian 8 / stable** (jessie)
+* **Debian testing** (stretch)
 * **Debian unstable** (sid)
 
 **Supported Linux Mint versions:**
 
 * **Linux Mint 13 "Maya"** (via Ubuntu 12.04 LTS)
 * **Linux Mint 17 "Qiana"** (via Ubuntu 14.04 LTS)
-* **Linux Mint Debian Edition (LMDE) stable** (via Debian stable)
-* **Linux Mint Debian Edition (LMDE) testing** (via Debian testing)
-* **Linux Mint Debian Edition (LMDE) unstable** (via Debian unstable)
+* **Linux Mint 17.1 "Rebecca"** (via Ubuntu 14.04 LTS)
+* **Linux Mint 17.2 "Rafaela"** (via Ubuntu 14.04 LTS)
+* **Linux Mint Debian Edition (LMDE) 2 "Betsy"** (via Debian 8)
 
 **Supported elementary OS versions:**
 
@@ -62,6 +63,10 @@ NodeSource will maintain support for stable, testing and unstable releases of De
 
 * **Trisquel 6 "Toutatis"** (via Ubuntu 12.04 LTS)
 * **Trisquel 7 "Belenos"** (via Ubuntu 14.04 LTS)
+
+**Supported BOSS versions:**
+
+* **BOSS 5.0 "Anokha"** (via Debian 7)
 
 <a name="debusage"></a>
 ### Usage instructions
@@ -158,6 +163,7 @@ NodeSource will continue to maintain the following architectures and may add add
 
 **Supported Fedora versions:**
 
+* **Fedora 21 (Twenty One)** (32-bit and 64-bit)
 * **Fedora 20 (Heisenbug)** (32-bit and 64-bit)
 * **Fedora 19 (Schrödinger's Cat)** (32-bit and 64-bit)
 

--- a/deb/setup
+++ b/deb/setup
@@ -87,6 +87,7 @@ check_alt "elementaryOS"  "luna"     "Ubuntu" "precise"
 check_alt "elementaryOS"  "freya"    "Ubuntu" "trusty"
 check_alt "Trisquel"      "toutatis" "Ubuntu" "precise"
 check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
+check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/setup
+++ b/deb/setup
@@ -78,6 +78,7 @@ check_alt() {
     fi
 }
 
+check_alt "Linux Mint"    "rafaela"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rebecca"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "qiana"    "Ubuntu" "trusty"
 check_alt "Linux Mint"    "maya"     "Ubuntu" "precise"

--- a/deb/setup_0.10
+++ b/deb/setup_0.10
@@ -87,6 +87,7 @@ check_alt "elementaryOS"  "luna"     "Ubuntu" "precise"
 check_alt "elementaryOS"  "freya"    "Ubuntu" "trusty"
 check_alt "Trisquel"      "toutatis" "Ubuntu" "precise"
 check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
+check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/setup_0.10
+++ b/deb/setup_0.10
@@ -78,6 +78,7 @@ check_alt() {
     fi
 }
 
+check_alt "Linux Mint"    "rafaela"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rebecca"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "qiana"    "Ubuntu" "trusty"
 check_alt "Linux Mint"    "maya"     "Ubuntu" "precise"

--- a/deb/setup_0.12
+++ b/deb/setup_0.12
@@ -87,6 +87,7 @@ check_alt "elementaryOS"  "luna"     "Ubuntu" "precise"
 check_alt "elementaryOS"  "freya"    "Ubuntu" "trusty"
 check_alt "Trisquel"      "toutatis" "Ubuntu" "precise"
 check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
+check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/setup_0.12
+++ b/deb/setup_0.12
@@ -78,6 +78,7 @@ check_alt() {
     fi
 }
 
+check_alt "Linux Mint"    "rafaela"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rebecca"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "qiana"    "Ubuntu" "trusty"
 check_alt "Linux Mint"    "maya"     "Ubuntu" "precise"

--- a/deb/setup_dev
+++ b/deb/setup_dev
@@ -87,6 +87,7 @@ check_alt "elementaryOS"  "luna"     "Ubuntu" "precise"
 check_alt "elementaryOS"  "freya"    "Ubuntu" "trusty"
 check_alt "Trisquel"      "toutatis" "Ubuntu" "precise"
 check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
+check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/setup_dev
+++ b/deb/setup_dev
@@ -78,6 +78,7 @@ check_alt() {
     fi
 }
 
+check_alt "Linux Mint"    "rafaela"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rebecca"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "qiana"    "Ubuntu" "trusty"
 check_alt "Linux Mint"    "maya"     "Ubuntu" "precise"

--- a/deb/setup_iojs_1.x
+++ b/deb/setup_iojs_1.x
@@ -87,6 +87,7 @@ check_alt "elementaryOS"  "luna"     "Ubuntu" "precise"
 check_alt "elementaryOS"  "freya"    "Ubuntu" "trusty"
 check_alt "Trisquel"      "toutatis" "Ubuntu" "precise"
 check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
+check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/setup_iojs_1.x
+++ b/deb/setup_iojs_1.x
@@ -78,6 +78,7 @@ check_alt() {
     fi
 }
 
+check_alt "Linux Mint"    "rafaela"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rebecca"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "qiana"    "Ubuntu" "trusty"
 check_alt "Linux Mint"    "maya"     "Ubuntu" "precise"

--- a/deb/setup_iojs_2.x
+++ b/deb/setup_iojs_2.x
@@ -87,6 +87,7 @@ check_alt "elementaryOS"  "luna"     "Ubuntu" "precise"
 check_alt "elementaryOS"  "freya"    "Ubuntu" "trusty"
 check_alt "Trisquel"      "toutatis" "Ubuntu" "precise"
 check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
+check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/setup_iojs_2.x
+++ b/deb/setup_iojs_2.x
@@ -78,6 +78,7 @@ check_alt() {
     fi
 }
 
+check_alt "Linux Mint"    "rafaela"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rebecca"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "qiana"    "Ubuntu" "trusty"
 check_alt "Linux Mint"    "maya"     "Ubuntu" "precise"

--- a/deb/src/_setup.sh
+++ b/deb/src/_setup.sh
@@ -87,6 +87,7 @@ check_alt "elementaryOS"  "luna"     "Ubuntu" "precise"
 check_alt "elementaryOS"  "freya"    "Ubuntu" "trusty"
 check_alt "Trisquel"      "toutatis" "Ubuntu" "precise"
 check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
+check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/src/_setup.sh
+++ b/deb/src/_setup.sh
@@ -78,6 +78,7 @@ check_alt() {
     fi
 }
 
+check_alt "Linux Mint"    "rafaela"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rebecca"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "qiana"    "Ubuntu" "trusty"
 check_alt "Linux Mint"    "maya"     "Ubuntu" "precise"


### PR DESCRIPTION
Adds a few more supported distributions:
+ Linux Mint 17.2, via Ubuntu 14.04 LTS (Fixes #99)
+ BOSS 5, via Debian 7 (Fixes #26) 

Also updates README accordingly:
+ Adds Linux Mint 17.2 "Rafaela"
+ Adds BOSS 5 "Anokha"
+ Adds Fedora 21 "Twenty One"

(FWIW, I also confirmed dists are working via VM.)