### PR TITLE
Add Kali Linux 2 support

### DIFF
--- a/deb/src/_setup.sh
+++ b/deb/src/_setup.sh
@@ -78,7 +78,8 @@ check_alt() {
     fi
 }
 
-check_alt "Debian"        "stretch" "Debian" "jessie"
+check_alt "Kali"          "sana"     "Debian" "jessie"
+check_alt "Debian"        "stretch"  "Debian" "jessie"
 check_alt "Linux Mint"    "rafaela"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rebecca"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "qiana"    "Ubuntu" "trusty"


### PR DESCRIPTION
This adds installation support of node in Kali Linux 2.0, a Debian Jessie based distro.