### PR TITLE
Include Kali Linux 2.0

### DIFF
--- a/deb/setup_4.x
+++ b/deb/setup_4.x
@@ -78,7 +78,8 @@ check_alt() {
     fi
 }
 
-check_alt "Debian"        "stretch" "Debian" "jessie"
+check_alt "Kali"          "sana"     "Debian" "jessie"
+check_alt "Debian"        "stretch"  "Debian" "jessie"
 check_alt "Linux Mint"    "rafaela"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rebecca"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "qiana"    "Ubuntu" "trusty"


### PR DESCRIPTION
Include Kali Linux 2.0 distro as a Debian Jessie derivate