### PR TITLE
Support paths with spaces

### DIFF
--- a/test/test
+++ b/test/test
@@ -12,7 +12,7 @@ print_status() {
 
 cleanup() {
     print_status "Cleaning up ..."
-    cd $OWD
+    cd "${OWD}"
     exec_cmd "rm -rf ${TEST_DIR}"
 }
 


### PR DESCRIPTION
Currently, the test script doesn't work quite as intended if (for whatever reason) someone is in a path containing a space.