### PR TITLE
Update Node.js 0.12 rpm url

### DIFF
--- a/rpm/setup_0.12
+++ b/rpm/setup_0.12
@@ -122,15 +122,14 @@ fi
 
 
 ## Given the distro, version and arch, construct the url for
-## the appropriate nodesource-release package (it's noarch but
-## we include the arch in the directory tree anyway)
+## the appropriate nodesource-release package
 RELEASE_URL_VERSION_STRING="${DIST_TYPE}${DIST_VERSION}"
 RELEASE_URL="\
 https://rpm.nodesource.com/pub_0.12/\
 ${DIST_TYPE}/\
 ${DIST_VERSION}/\
 ${DIST_ARCH}/\
-nodesource-release-${RELEASE_URL_VERSION_STRING}-1.noarch.rpm"
+nodejs-0.12.9-1nodesource.${RELEASE_URL_VERSION_STRING}.${DIST_ARCH}.rpm"
 
 #-check-distro-#
 


### PR DESCRIPTION
Update the rpm URL to match what is available on rpm.nodesource.com and solve the problem cited in numerous issues (#197, #205, #185, #152, #124, #117, #107, #84).