### PR TITLE
Add support for Korora Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,9 @@ NodeSource will continue to maintain the following architectures and may add add
 * **Fedora 22 (Twenty Two)** (32-bit and 64-bit)
 * **Fedora 21 (Twenty One)** (32-bit and 64-bit)
 
+> This script should also work for all equivalent versions of Korora
+> Linux.
+
 <a name="rpminstall"></a>
 ### Installation instructions
 

--- a/rpm/setup
+++ b/rpm/setup
@@ -79,7 +79,7 @@ if [[ $DISTRO_PKG =~ ^(redhat|centos|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^system-release- ]]; then # Amazon Linux
     DIST_TYPE=el
-elif [[ $DISTRO_PKG =~ ^fedora- ]]; then
+elif [[ $DISTRO_PKG =~ ^(fedora|korora)- ]]; then
     DIST_TYPE=fc
 else
 

--- a/rpm/setup_0.10
+++ b/rpm/setup_0.10
@@ -79,7 +79,7 @@ if [[ $DISTRO_PKG =~ ^(redhat|centos|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^system-release- ]]; then # Amazon Linux
     DIST_TYPE=el
-elif [[ $DISTRO_PKG =~ ^fedora- ]]; then
+elif [[ $DISTRO_PKG =~ ^(fedora|korora)- ]]; then
     DIST_TYPE=fc
 else
 

--- a/rpm/setup_0.12
+++ b/rpm/setup_0.12
@@ -79,7 +79,7 @@ if [[ $DISTRO_PKG =~ ^(redhat|centos|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^system-release- ]]; then # Amazon Linux
     DIST_TYPE=el
-elif [[ $DISTRO_PKG =~ ^fedora- ]]; then
+elif [[ $DISTRO_PKG =~ ^(fedora|korora)- ]]; then
     DIST_TYPE=fc
 else
 

--- a/rpm/setup_4.x
+++ b/rpm/setup_4.x
@@ -79,7 +79,7 @@ if [[ $DISTRO_PKG =~ ^(redhat|centos|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^system-release- ]]; then # Amazon Linux
     DIST_TYPE=el
-elif [[ $DISTRO_PKG =~ ^fedora- ]]; then
+elif [[ $DISTRO_PKG =~ ^(fedora|korora)- ]]; then
     DIST_TYPE=fc
 else
 

--- a/rpm/setup_5.x
+++ b/rpm/setup_5.x
@@ -79,7 +79,7 @@ if [[ $DISTRO_PKG =~ ^(redhat|centos|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^system-release- ]]; then # Amazon Linux
     DIST_TYPE=el
-elif [[ $DISTRO_PKG =~ ^fedora- ]]; then
+elif [[ $DISTRO_PKG =~ ^(fedora|korora)- ]]; then
     DIST_TYPE=fc
 else
 

--- a/rpm/setup_iojs_1.x
+++ b/rpm/setup_iojs_1.x
@@ -79,7 +79,7 @@ if [[ $DISTRO_PKG =~ ^(redhat|centos|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^system-release- ]]; then # Amazon Linux
     DIST_TYPE=el
-elif [[ $DISTRO_PKG =~ ^fedora- ]]; then
+elif [[ $DISTRO_PKG =~ ^(fedora|korora)- ]]; then
     DIST_TYPE=fc
 else
 

--- a/rpm/setup_iojs_2.x
+++ b/rpm/setup_iojs_2.x
@@ -79,7 +79,7 @@ if [[ $DISTRO_PKG =~ ^(redhat|centos|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^system-release- ]]; then # Amazon Linux
     DIST_TYPE=el
-elif [[ $DISTRO_PKG =~ ^fedora- ]]; then
+elif [[ $DISTRO_PKG =~ ^(fedora|korora)- ]]; then
     DIST_TYPE=fc
 else
 


### PR DESCRIPTION
Korora is really just a preconfigured Fedora, and tracks upstream closely.

I almost didn't notice how easy the fix was, and almost gave up on getting the rpm!

Related: https://github.com/nodesource/distributions/issues/130