### PR TITLE
add v0.10 and v0.12 EOL warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ If you are looking for NodeSource's Enterprise-grade Node.js platform, **[N|Soli
 
 ----------------------------------
 
+> IMPORTANT: Official support for Node.js v0.12 ceases at the end of 2016
+> Please prepare to migrate to Node.js v4 LTS or a later version.
+
+----------------------------------
+
 For **Debian / Ubuntu** based distributions, see the **[deb](./deb)** directory for the source of the two setup scripts located at <https://deb.nodesource.com/setup> and <https://deb.nodesource.com/setup_dev>.
 
 For **Enterprise Linux** based distributions (Red Hat® Enterprise Linux® / RHEL, CentOS, CloudLinux, Fedora), see the **[rpm](./rpm)** directory for the source of setup script located at <https://rpm.nodesource.com/setup>.

--- a/deb/setup
+++ b/deb/setup
@@ -17,7 +17,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 print_status() {
     echo
-    echo "## $1"
+    echo -e "## $1"
     echo
 }
 
@@ -145,3 +145,19 @@ print_status 'Running `apt-get update` for you...'
 exec_cmd 'apt-get update'
 
 print_status 'Run `apt-get install nodejs` (as root) to install Node.js v0.10 and npm'
+
+if [ "node_0.10" = "node_0.10" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.10 ceases in October 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+elif [ "node_0.10" = "node_0.12" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.12 ceases at the end of 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+fi

--- a/deb/setup_0.10
+++ b/deb/setup_0.10
@@ -17,7 +17,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 print_status() {
     echo
-    echo "## $1"
+    echo -e "## $1"
     echo
 }
 
@@ -145,3 +145,19 @@ print_status 'Running `apt-get update` for you...'
 exec_cmd 'apt-get update'
 
 print_status 'Run `apt-get install nodejs` (as root) to install Node.js v0.10 and npm'
+
+if [ "node_0.10" = "node_0.10" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.10 ceases in October 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+elif [ "node_0.10" = "node_0.12" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.12 ceases at the end of 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+fi

--- a/deb/setup_0.12
+++ b/deb/setup_0.12
@@ -17,7 +17,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 print_status() {
     echo
-    echo "## $1"
+    echo -e "## $1"
     echo
 }
 
@@ -145,3 +145,19 @@ print_status 'Running `apt-get update` for you...'
 exec_cmd 'apt-get update'
 
 print_status 'Run `apt-get install nodejs` (as root) to install Node.js v0.12 and npm'
+
+if [ "node_0.12" = "node_0.10" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.10 ceases in October 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+elif [ "node_0.12" = "node_0.12" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.12 ceases at the end of 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+fi

--- a/deb/setup_4.x
+++ b/deb/setup_4.x
@@ -17,7 +17,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 print_status() {
     echo
-    echo "## $1"
+    echo -e "## $1"
     echo
 }
 
@@ -145,3 +145,19 @@ print_status 'Running `apt-get update` for you...'
 exec_cmd 'apt-get update'
 
 print_status 'Run `apt-get install nodejs` (as root) to install Node.js v4.x LTS Argon and npm'
+
+if [ "node_4.x" = "node_0.10" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.10 ceases in October 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+elif [ "node_4.x" = "node_0.12" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.12 ceases at the end of 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+fi

--- a/deb/setup_5.x
+++ b/deb/setup_5.x
@@ -17,7 +17,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 print_status() {
     echo
-    echo "## $1"
+    echo -e "## $1"
     echo
 }
 
@@ -145,3 +145,19 @@ print_status 'Running `apt-get update` for you...'
 exec_cmd 'apt-get update'
 
 print_status 'Run `apt-get install nodejs` (as root) to install Node.js v5.x and npm'
+
+if [ "node_5.x" = "node_0.10" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.10 ceases in October 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+elif [ "node_5.x" = "node_0.12" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.12 ceases at the end of 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+fi

--- a/deb/setup_6.x
+++ b/deb/setup_6.x
@@ -17,7 +17,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 print_status() {
     echo
-    echo "## $1"
+    echo -e "## $1"
     echo
 }
 
@@ -145,3 +145,19 @@ print_status 'Running `apt-get update` for you...'
 exec_cmd 'apt-get update'
 
 print_status 'Run `apt-get install nodejs` (as root) to install Node.js v6.x and npm'
+
+if [ "node_6.x" = "node_0.10" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.10 ceases in October 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+elif [ "node_6.x" = "node_0.12" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.12 ceases at the end of 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+fi

--- a/deb/setup_dev
+++ b/deb/setup_dev
@@ -17,7 +17,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 print_status() {
     echo
-    echo "## $1"
+    echo -e "## $1"
     echo
 }
 
@@ -145,3 +145,19 @@ print_status 'Running `apt-get update` for you...'
 exec_cmd 'apt-get update'
 
 print_status 'Run `apt-get install nodejs` (as root) to install Node.js v0.12 and npm'
+
+if [ "node_0.12" = "node_0.10" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.10 ceases in October 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+elif [ "node_0.12" = "node_0.12" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.12 ceases at the end of 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+fi

--- a/deb/setup_iojs_1.x
+++ b/deb/setup_iojs_1.x
@@ -17,7 +17,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 print_status() {
     echo
-    echo "## $1"
+    echo -e "## $1"
     echo
 }
 
@@ -145,3 +145,19 @@ print_status 'Running `apt-get update` for you...'
 exec_cmd 'apt-get update'
 
 print_status 'Run `apt-get install iojs` (as root) to install io.js v1.x and npm'
+
+if [ "iojs_1.x" = "node_0.10" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.10 ceases in October 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+elif [ "iojs_1.x" = "node_0.12" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.12 ceases at the end of 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+fi

--- a/deb/setup_iojs_2.x
+++ b/deb/setup_iojs_2.x
@@ -17,7 +17,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 print_status() {
     echo
-    echo "## $1"
+    echo -e "## $1"
     echo
 }
 
@@ -145,3 +145,19 @@ print_status 'Running `apt-get update` for you...'
 exec_cmd 'apt-get update'
 
 print_status 'Run `apt-get install iojs` (as root) to install io.js v2.x and npm'
+
+if [ "iojs_2.x" = "node_0.10" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.10 ceases in October 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+elif [ "iojs_2.x" = "node_0.12" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.12 ceases at the end of 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+fi

--- a/deb/setup_iojs_3.x
+++ b/deb/setup_iojs_3.x
@@ -17,7 +17,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 print_status() {
     echo
-    echo "## $1"
+    echo -e "## $1"
     echo
 }
 
@@ -145,3 +145,19 @@ print_status 'Running `apt-get update` for you...'
 exec_cmd 'apt-get update'
 
 print_status 'Run `apt-get install iojs` (as root) to install io.js v3.x and npm'
+
+if [ "iojs_3.x" = "node_0.10" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.10 ceases in October 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+elif [ "iojs_3.x" = "node_0.12" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.12 ceases at the end of 2016
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+fi

--- a/deb/src/_setup.sh
+++ b/deb/src/_setup.sh
@@ -17,7 +17,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 print_status() {
     echo
-    echo "## $1"
+    echo -e "## $1"
     echo
 }
 
@@ -145,3 +145,19 @@ print_status 'Running `apt-get update` for you...'
 exec_cmd 'apt-get update'
 
 print_status 'Run `apt-get install {{package}}` (as root) to install {{name}} and npm'
+
+if [ "{{repo}}" = "node_0.10" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.10 ceases in October 2016.
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+elif [ "{{repo}}" = "node_0.12" ]; then
+
+    print_status \
+'IMPORTANT: Official support for Node.js v0.12 ceases at the end of 2016.
+## Please prepare to migrate to Node.js v4 LTS or a later version.
+## See https://deb.nodesource.com for details on how to use a newer version.'
+
+fi


### PR DESCRIPTION
@chrislea, @retrohacker, @julianduque, others? what do you think of adding a warning? It'll make most sense for people blindly using `https://deb.nodesource.com/setup` which we're probably going to have to do something more drastic with in October, like bring out a huge ascii art banner saying EOL.