### PR TITLE
add deprecation warnings

### DIFF
--- a/deb/setup
+++ b/deb/setup
@@ -14,6 +14,10 @@
 #
 
 export DEBIAN_FRONTEND=noninteractive
+SCRSUFFIX=""
+NODENAME="Node.js v0.10"
+NODEREPO="node_0.10"
+NODEPKG="nodejs"
 
 print_status() {
     echo
@@ -71,7 +75,7 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "XNode.js v0.10" == "XNode.js v0.10" ]; then
+    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
 Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
@@ -99,10 +103,10 @@ Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
-    elif [ "XNode.js v0.10" == "XNode.js v0.12" ]; then
+    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported ${bold}at the end of 2016${normal}.
+Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -131,7 +135,7 @@ Node.js v0.10 will cease to be actively supported ${bold}at the end of 2016${nor
 }
 
 script_deprecation_warning() {
-    if [ "X" == "X" ]; then
+    if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
 "                            DEPRECATION WARNING                            " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
@@ -164,7 +168,7 @@ setup() {
 
 script_deprecation_warning
 
-print_status "Installing the NodeSource Node.js v0.10 repo..."
+print_status "Installing the NodeSource ${NODENAME} repo..."
 
 
 PRE_INSTALL_PKGS=""
@@ -237,10 +241,10 @@ fi
 print_status "Confirming \"${DISTRO}\" is supported..."
 
 if [ -x /usr/bin/curl ]; then
-    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/node_0.10/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 else
-    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/node_0.10/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 fi
 
@@ -264,10 +268,10 @@ else
     exec_cmd 'wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -'
 fi
 
-print_status 'Creating apt sources list file for the NodeSource Node.js v0.10 repo...'
+print_status 'Creating apt sources list file for the NodeSource ${NODENAME} repo...'
 
-exec_cmd "echo 'deb https://deb.nodesource.com/node_0.10 ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
-exec_cmd "echo 'deb-src https://deb.nodesource.com/node_0.10 ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb-src https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
 
 print_status 'Running `apt-get update` for you...'
 
@@ -275,7 +279,7 @@ exec_cmd 'apt-get update'
 
 node_deprecation_warning
 
-print_status 'Run `apt-get install nodejs` (as root) to install Node.js v0.10 and npm'
+print_status 'Run `apt-get install ${NODEPKG}` (as root) to install ${NODENAME} and npm'
 
 }
 

--- a/deb/setup
+++ b/deb/setup
@@ -21,6 +21,41 @@ print_status() {
     echo
 }
 
+if test -t 1; then # if terminal
+    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        termcols=$(tput cols)
+        bold="$(tput bold)"
+        underline="$(tput smul)"
+        standout="$(tput smso)"
+        normal="$(tput sgr0)"
+        black="$(tput setaf 0)"
+        red="$(tput setaf 1)"
+        green="$(tput setaf 2)"
+        yellow="$(tput setaf 3)"
+        blue="$(tput setaf 4)"
+        magenta="$(tput setaf 5)"
+        cyan="$(tput setaf 6)"
+        white="$(tput setaf 7)"
+    fi
+fi
+
+print_bold() {
+    title="$1"
+    text="$2"
+
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+    echo
+    echo -e "  ${bold}${yellow}${title}${normal}"
+    echo
+    echo -en "  ${text}"
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+}
+
 bail() {
     echo 'Error executing command, exiting'
     exit 1
@@ -35,8 +70,99 @@ exec_cmd() {
     exec_cmd_nobail "$1" || bail
 }
 
+node_deprecation_warning() {
+    if [ "XNode.js v0.10" == "XNode.js v0.10" ]; then
+        print_bold \
+"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
+Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 5 seconds ..."
+        echo
+        sleep 5
+    elif [ "XNode.js v0.10" == "XNode.js v0.12" ]; then
+        print_bold \
+"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
+Node.js v0.10 will cease to be actively supported ${bold}at the end of 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 3 seconds ..."
+        echo
+        sleep 3
+    fi
+}
+
+script_deprecation_warning() {
+    if [ "X" == "X" ]; then
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
+  install Node.js v0.10, is being deprecated and will eventually be made
+  inactive.
+
+  You should use the script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo
+        sleep 10
+    fi
+}
 
 setup() {
+
+script_deprecation_warning
 
 print_status "Installing the NodeSource Node.js v0.10 repo..."
 
@@ -146,6 +272,8 @@ exec_cmd "echo 'deb-src https://deb.nodesource.com/node_0.10 ${DISTRO} main' >> 
 print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
+
+node_deprecation_warning
 
 print_status 'Run `apt-get install nodejs` (as root) to install Node.js v0.10 and npm'
 

--- a/deb/setup
+++ b/deb/setup
@@ -75,7 +75,39 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
+          "X${NODENAME}" == "Xio.js v2.x" ||
+          "X${NODENAME}" == "Xio.js v3.x" ||
+          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+${bold}${NODENAME} is no longer actively supported!${normal}
+
+  ${bold}You will not receive security or critical stability updates${normal} for this version.
+
+  You should migrate to a supported version of Node.js as soon as possible.
+  Use the installation script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+        echo
+        echo "Continuing in 10 seconds ..."
+        echo
+        sleep 10
+
+    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
 Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
@@ -103,7 +135,9 @@ Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
+
     elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
+
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
 Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
@@ -131,13 +165,14 @@ Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${nor
         echo "Continuing in 3 seconds ..."
         echo
         sleep 3
+
     fi
 }
 
 script_deprecation_warning() {
     if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
-"                            DEPRECATION WARNING                            " "\
+"                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
   install Node.js v0.10, is being deprecated and will eventually be made
   inactive.

--- a/deb/setup_0.10
+++ b/deb/setup_0.10
@@ -14,6 +14,10 @@
 #
 
 export DEBIAN_FRONTEND=noninteractive
+SCRSUFFIX="_0.10"
+NODENAME="Node.js v0.10"
+NODEREPO="node_0.10"
+NODEPKG="nodejs"
 
 print_status() {
     echo
@@ -71,7 +75,7 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "XNode.js v0.10" == "XNode.js v0.10" ]; then
+    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
 Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
@@ -99,10 +103,10 @@ Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
-    elif [ "XNode.js v0.10" == "XNode.js v0.12" ]; then
+    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported ${bold}at the end of 2016${normal}.
+Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -131,7 +135,7 @@ Node.js v0.10 will cease to be actively supported ${bold}at the end of 2016${nor
 }
 
 script_deprecation_warning() {
-    if [ "X_0.10" == "X" ]; then
+    if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
 "                            DEPRECATION WARNING                            " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
@@ -164,7 +168,7 @@ setup() {
 
 script_deprecation_warning
 
-print_status "Installing the NodeSource Node.js v0.10 repo..."
+print_status "Installing the NodeSource ${NODENAME} repo..."
 
 
 PRE_INSTALL_PKGS=""
@@ -237,10 +241,10 @@ fi
 print_status "Confirming \"${DISTRO}\" is supported..."
 
 if [ -x /usr/bin/curl ]; then
-    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/node_0.10/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 else
-    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/node_0.10/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 fi
 
@@ -264,10 +268,10 @@ else
     exec_cmd 'wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -'
 fi
 
-print_status 'Creating apt sources list file for the NodeSource Node.js v0.10 repo...'
+print_status 'Creating apt sources list file for the NodeSource ${NODENAME} repo...'
 
-exec_cmd "echo 'deb https://deb.nodesource.com/node_0.10 ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
-exec_cmd "echo 'deb-src https://deb.nodesource.com/node_0.10 ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb-src https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
 
 print_status 'Running `apt-get update` for you...'
 
@@ -275,7 +279,7 @@ exec_cmd 'apt-get update'
 
 node_deprecation_warning
 
-print_status 'Run `apt-get install nodejs` (as root) to install Node.js v0.10 and npm'
+print_status 'Run `apt-get install ${NODEPKG}` (as root) to install ${NODENAME} and npm'
 
 }
 

--- a/deb/setup_0.10
+++ b/deb/setup_0.10
@@ -21,6 +21,41 @@ print_status() {
     echo
 }
 
+if test -t 1; then # if terminal
+    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        termcols=$(tput cols)
+        bold="$(tput bold)"
+        underline="$(tput smul)"
+        standout="$(tput smso)"
+        normal="$(tput sgr0)"
+        black="$(tput setaf 0)"
+        red="$(tput setaf 1)"
+        green="$(tput setaf 2)"
+        yellow="$(tput setaf 3)"
+        blue="$(tput setaf 4)"
+        magenta="$(tput setaf 5)"
+        cyan="$(tput setaf 6)"
+        white="$(tput setaf 7)"
+    fi
+fi
+
+print_bold() {
+    title="$1"
+    text="$2"
+
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+    echo
+    echo -e "  ${bold}${yellow}${title}${normal}"
+    echo
+    echo -en "  ${text}"
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+}
+
 bail() {
     echo 'Error executing command, exiting'
     exit 1
@@ -35,8 +70,99 @@ exec_cmd() {
     exec_cmd_nobail "$1" || bail
 }
 
+node_deprecation_warning() {
+    if [ "XNode.js v0.10" == "XNode.js v0.10" ]; then
+        print_bold \
+"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
+Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 5 seconds ..."
+        echo
+        sleep 5
+    elif [ "XNode.js v0.10" == "XNode.js v0.12" ]; then
+        print_bold \
+"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
+Node.js v0.10 will cease to be actively supported ${bold}at the end of 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 3 seconds ..."
+        echo
+        sleep 3
+    fi
+}
+
+script_deprecation_warning() {
+    if [ "X_0.10" == "X" ]; then
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
+  install Node.js v0.10, is being deprecated and will eventually be made
+  inactive.
+
+  You should use the script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo
+        sleep 10
+    fi
+}
 
 setup() {
+
+script_deprecation_warning
 
 print_status "Installing the NodeSource Node.js v0.10 repo..."
 
@@ -146,6 +272,8 @@ exec_cmd "echo 'deb-src https://deb.nodesource.com/node_0.10 ${DISTRO} main' >> 
 print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
+
+node_deprecation_warning
 
 print_status 'Run `apt-get install nodejs` (as root) to install Node.js v0.10 and npm'
 

--- a/deb/setup_0.10
+++ b/deb/setup_0.10
@@ -75,7 +75,39 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
+          "X${NODENAME}" == "Xio.js v2.x" ||
+          "X${NODENAME}" == "Xio.js v3.x" ||
+          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+${bold}${NODENAME} is no longer actively supported!${normal}
+
+  ${bold}You will not receive security or critical stability updates${normal} for this version.
+
+  You should migrate to a supported version of Node.js as soon as possible.
+  Use the installation script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+        echo
+        echo "Continuing in 10 seconds ..."
+        echo
+        sleep 10
+
+    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
 Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
@@ -103,7 +135,9 @@ Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
+
     elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
+
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
 Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
@@ -131,13 +165,14 @@ Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${nor
         echo "Continuing in 3 seconds ..."
         echo
         sleep 3
+
     fi
 }
 
 script_deprecation_warning() {
     if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
-"                            DEPRECATION WARNING                            " "\
+"                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
   install Node.js v0.10, is being deprecated and will eventually be made
   inactive.

--- a/deb/setup_0.12
+++ b/deb/setup_0.12
@@ -21,6 +21,41 @@ print_status() {
     echo
 }
 
+if test -t 1; then # if terminal
+    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        termcols=$(tput cols)
+        bold="$(tput bold)"
+        underline="$(tput smul)"
+        standout="$(tput smso)"
+        normal="$(tput sgr0)"
+        black="$(tput setaf 0)"
+        red="$(tput setaf 1)"
+        green="$(tput setaf 2)"
+        yellow="$(tput setaf 3)"
+        blue="$(tput setaf 4)"
+        magenta="$(tput setaf 5)"
+        cyan="$(tput setaf 6)"
+        white="$(tput setaf 7)"
+    fi
+fi
+
+print_bold() {
+    title="$1"
+    text="$2"
+
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+    echo
+    echo -e "  ${bold}${yellow}${title}${normal}"
+    echo
+    echo -en "  ${text}"
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+}
+
 bail() {
     echo 'Error executing command, exiting'
     exit 1
@@ -35,8 +70,99 @@ exec_cmd() {
     exec_cmd_nobail "$1" || bail
 }
 
+node_deprecation_warning() {
+    if [ "XNode.js v0.12" == "XNode.js v0.10" ]; then
+        print_bold \
+"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
+Node.js v0.12 will cease to be actively supported in ${bold}October 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 5 seconds ..."
+        echo
+        sleep 5
+    elif [ "XNode.js v0.12" == "XNode.js v0.12" ]; then
+        print_bold \
+"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
+Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 3 seconds ..."
+        echo
+        sleep 3
+    fi
+}
+
+script_deprecation_warning() {
+    if [ "X_0.12" == "X" ]; then
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
+  install Node.js v0.12, is being deprecated and will eventually be made
+  inactive.
+
+  You should use the script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo
+        sleep 10
+    fi
+}
 
 setup() {
+
+script_deprecation_warning
 
 print_status "Installing the NodeSource Node.js v0.12 repo..."
 
@@ -146,6 +272,8 @@ exec_cmd "echo 'deb-src https://deb.nodesource.com/node_0.12 ${DISTRO} main' >> 
 print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
+
+node_deprecation_warning
 
 print_status 'Run `apt-get install nodejs` (as root) to install Node.js v0.12 and npm'
 

--- a/deb/setup_0.12
+++ b/deb/setup_0.12
@@ -14,6 +14,10 @@
 #
 
 export DEBIAN_FRONTEND=noninteractive
+SCRSUFFIX="_0.12"
+NODENAME="Node.js v0.12"
+NODEREPO="node_0.12"
+NODEPKG="nodejs"
 
 print_status() {
     echo
@@ -71,10 +75,10 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "XNode.js v0.12" == "XNode.js v0.10" ]; then
+    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported in ${bold}October 2016${normal}.
+Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -99,7 +103,7 @@ Node.js v0.12 will cease to be actively supported in ${bold}October 2016${normal
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
-    elif [ "XNode.js v0.12" == "XNode.js v0.12" ]; then
+    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
 Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
@@ -131,11 +135,11 @@ Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${nor
 }
 
 script_deprecation_warning() {
-    if [ "X_0.12" == "X" ]; then
+    if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
 "                            DEPRECATION WARNING                            " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v0.12, is being deprecated and will eventually be made
+  install Node.js v0.10, is being deprecated and will eventually be made
   inactive.
 
   You should use the script that corresponds to the version of Node.js you
@@ -164,7 +168,7 @@ setup() {
 
 script_deprecation_warning
 
-print_status "Installing the NodeSource Node.js v0.12 repo..."
+print_status "Installing the NodeSource ${NODENAME} repo..."
 
 
 PRE_INSTALL_PKGS=""
@@ -237,10 +241,10 @@ fi
 print_status "Confirming \"${DISTRO}\" is supported..."
 
 if [ -x /usr/bin/curl ]; then
-    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/node_0.12/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 else
-    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/node_0.12/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 fi
 
@@ -264,10 +268,10 @@ else
     exec_cmd 'wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -'
 fi
 
-print_status 'Creating apt sources list file for the NodeSource Node.js v0.12 repo...'
+print_status 'Creating apt sources list file for the NodeSource ${NODENAME} repo...'
 
-exec_cmd "echo 'deb https://deb.nodesource.com/node_0.12 ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
-exec_cmd "echo 'deb-src https://deb.nodesource.com/node_0.12 ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb-src https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
 
 print_status 'Running `apt-get update` for you...'
 
@@ -275,7 +279,7 @@ exec_cmd 'apt-get update'
 
 node_deprecation_warning
 
-print_status 'Run `apt-get install nodejs` (as root) to install Node.js v0.12 and npm'
+print_status 'Run `apt-get install ${NODEPKG}` (as root) to install ${NODENAME} and npm'
 
 }
 

--- a/deb/setup_0.12
+++ b/deb/setup_0.12
@@ -75,7 +75,39 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
+          "X${NODENAME}" == "Xio.js v2.x" ||
+          "X${NODENAME}" == "Xio.js v3.x" ||
+          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+${bold}${NODENAME} is no longer actively supported!${normal}
+
+  ${bold}You will not receive security or critical stability updates${normal} for this version.
+
+  You should migrate to a supported version of Node.js as soon as possible.
+  Use the installation script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+        echo
+        echo "Continuing in 10 seconds ..."
+        echo
+        sleep 10
+
+    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
 Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
@@ -103,7 +135,9 @@ Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
+
     elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
+
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
 Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
@@ -131,13 +165,14 @@ Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${nor
         echo "Continuing in 3 seconds ..."
         echo
         sleep 3
+
     fi
 }
 
 script_deprecation_warning() {
     if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
-"                            DEPRECATION WARNING                            " "\
+"                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
   install Node.js v0.10, is being deprecated and will eventually be made
   inactive.

--- a/deb/setup_4.x
+++ b/deb/setup_4.x
@@ -14,6 +14,10 @@
 #
 
 export DEBIAN_FRONTEND=noninteractive
+SCRSUFFIX="_4.x"
+NODENAME="Node.js v4.x LTS Argon"
+NODEREPO="node_4.x"
+NODEPKG="nodejs"
 
 print_status() {
     echo
@@ -71,10 +75,10 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "XNode.js v4.x LTS Argon" == "XNode.js v0.10" ]; then
+    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v4.x LTS Argon will cease to be actively supported in ${bold}October 2016${normal}.
+Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -99,10 +103,10 @@ Node.js v4.x LTS Argon will cease to be actively supported in ${bold}October 201
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
-    elif [ "XNode.js v4.x LTS Argon" == "XNode.js v0.12" ]; then
+    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v4.x LTS Argon will cease to be actively supported ${bold}at the end of 2016${normal}.
+Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -131,11 +135,11 @@ Node.js v4.x LTS Argon will cease to be actively supported ${bold}at the end of 
 }
 
 script_deprecation_warning() {
-    if [ "X_4.x" == "X" ]; then
+    if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
 "                            DEPRECATION WARNING                            " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v4.x LTS Argon, is being deprecated and will eventually be made
+  install Node.js v0.10, is being deprecated and will eventually be made
   inactive.
 
   You should use the script that corresponds to the version of Node.js you
@@ -164,7 +168,7 @@ setup() {
 
 script_deprecation_warning
 
-print_status "Installing the NodeSource Node.js v4.x LTS Argon repo..."
+print_status "Installing the NodeSource ${NODENAME} repo..."
 
 
 PRE_INSTALL_PKGS=""
@@ -237,10 +241,10 @@ fi
 print_status "Confirming \"${DISTRO}\" is supported..."
 
 if [ -x /usr/bin/curl ]; then
-    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/node_4.x/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 else
-    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/node_4.x/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 fi
 
@@ -264,10 +268,10 @@ else
     exec_cmd 'wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -'
 fi
 
-print_status 'Creating apt sources list file for the NodeSource Node.js v4.x LTS Argon repo...'
+print_status 'Creating apt sources list file for the NodeSource ${NODENAME} repo...'
 
-exec_cmd "echo 'deb https://deb.nodesource.com/node_4.x ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
-exec_cmd "echo 'deb-src https://deb.nodesource.com/node_4.x ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb-src https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
 
 print_status 'Running `apt-get update` for you...'
 
@@ -275,7 +279,7 @@ exec_cmd 'apt-get update'
 
 node_deprecation_warning
 
-print_status 'Run `apt-get install nodejs` (as root) to install Node.js v4.x LTS Argon and npm'
+print_status 'Run `apt-get install ${NODEPKG}` (as root) to install ${NODENAME} and npm'
 
 }
 

--- a/deb/setup_4.x
+++ b/deb/setup_4.x
@@ -21,6 +21,41 @@ print_status() {
     echo
 }
 
+if test -t 1; then # if terminal
+    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        termcols=$(tput cols)
+        bold="$(tput bold)"
+        underline="$(tput smul)"
+        standout="$(tput smso)"
+        normal="$(tput sgr0)"
+        black="$(tput setaf 0)"
+        red="$(tput setaf 1)"
+        green="$(tput setaf 2)"
+        yellow="$(tput setaf 3)"
+        blue="$(tput setaf 4)"
+        magenta="$(tput setaf 5)"
+        cyan="$(tput setaf 6)"
+        white="$(tput setaf 7)"
+    fi
+fi
+
+print_bold() {
+    title="$1"
+    text="$2"
+
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+    echo
+    echo -e "  ${bold}${yellow}${title}${normal}"
+    echo
+    echo -en "  ${text}"
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+}
+
 bail() {
     echo 'Error executing command, exiting'
     exit 1
@@ -35,8 +70,99 @@ exec_cmd() {
     exec_cmd_nobail "$1" || bail
 }
 
+node_deprecation_warning() {
+    if [ "XNode.js v4.x LTS Argon" == "XNode.js v0.10" ]; then
+        print_bold \
+"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
+Node.js v4.x LTS Argon will cease to be actively supported in ${bold}October 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 5 seconds ..."
+        echo
+        sleep 5
+    elif [ "XNode.js v4.x LTS Argon" == "XNode.js v0.12" ]; then
+        print_bold \
+"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
+Node.js v4.x LTS Argon will cease to be actively supported ${bold}at the end of 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 3 seconds ..."
+        echo
+        sleep 3
+    fi
+}
+
+script_deprecation_warning() {
+    if [ "X_4.x" == "X" ]; then
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
+  install Node.js v4.x LTS Argon, is being deprecated and will eventually be made
+  inactive.
+
+  You should use the script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo
+        sleep 10
+    fi
+}
 
 setup() {
+
+script_deprecation_warning
 
 print_status "Installing the NodeSource Node.js v4.x LTS Argon repo..."
 
@@ -146,6 +272,8 @@ exec_cmd "echo 'deb-src https://deb.nodesource.com/node_4.x ${DISTRO} main' >> /
 print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
+
+node_deprecation_warning
 
 print_status 'Run `apt-get install nodejs` (as root) to install Node.js v4.x LTS Argon and npm'
 

--- a/deb/setup_4.x
+++ b/deb/setup_4.x
@@ -75,7 +75,39 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
+          "X${NODENAME}" == "Xio.js v2.x" ||
+          "X${NODENAME}" == "Xio.js v3.x" ||
+          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+${bold}${NODENAME} is no longer actively supported!${normal}
+
+  ${bold}You will not receive security or critical stability updates${normal} for this version.
+
+  You should migrate to a supported version of Node.js as soon as possible.
+  Use the installation script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+        echo
+        echo "Continuing in 10 seconds ..."
+        echo
+        sleep 10
+
+    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
 Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
@@ -103,7 +135,9 @@ Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
+
     elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
+
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
 Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
@@ -131,13 +165,14 @@ Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${nor
         echo "Continuing in 3 seconds ..."
         echo
         sleep 3
+
     fi
 }
 
 script_deprecation_warning() {
     if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
-"                            DEPRECATION WARNING                            " "\
+"                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
   install Node.js v0.10, is being deprecated and will eventually be made
   inactive.

--- a/deb/setup_5.x
+++ b/deb/setup_5.x
@@ -21,6 +21,41 @@ print_status() {
     echo
 }
 
+if test -t 1; then # if terminal
+    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        termcols=$(tput cols)
+        bold="$(tput bold)"
+        underline="$(tput smul)"
+        standout="$(tput smso)"
+        normal="$(tput sgr0)"
+        black="$(tput setaf 0)"
+        red="$(tput setaf 1)"
+        green="$(tput setaf 2)"
+        yellow="$(tput setaf 3)"
+        blue="$(tput setaf 4)"
+        magenta="$(tput setaf 5)"
+        cyan="$(tput setaf 6)"
+        white="$(tput setaf 7)"
+    fi
+fi
+
+print_bold() {
+    title="$1"
+    text="$2"
+
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+    echo
+    echo -e "  ${bold}${yellow}${title}${normal}"
+    echo
+    echo -en "  ${text}"
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+}
+
 bail() {
     echo 'Error executing command, exiting'
     exit 1
@@ -35,8 +70,99 @@ exec_cmd() {
     exec_cmd_nobail "$1" || bail
 }
 
+node_deprecation_warning() {
+    if [ "XNode.js v5.x" == "XNode.js v0.10" ]; then
+        print_bold \
+"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
+Node.js v5.x will cease to be actively supported in ${bold}October 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 5 seconds ..."
+        echo
+        sleep 5
+    elif [ "XNode.js v5.x" == "XNode.js v0.12" ]; then
+        print_bold \
+"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
+Node.js v5.x will cease to be actively supported ${bold}at the end of 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 3 seconds ..."
+        echo
+        sleep 3
+    fi
+}
+
+script_deprecation_warning() {
+    if [ "X_5.x" == "X" ]; then
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
+  install Node.js v5.x, is being deprecated and will eventually be made
+  inactive.
+
+  You should use the script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo
+        sleep 10
+    fi
+}
 
 setup() {
+
+script_deprecation_warning
 
 print_status "Installing the NodeSource Node.js v5.x repo..."
 
@@ -146,6 +272,8 @@ exec_cmd "echo 'deb-src https://deb.nodesource.com/node_5.x ${DISTRO} main' >> /
 print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
+
+node_deprecation_warning
 
 print_status 'Run `apt-get install nodejs` (as root) to install Node.js v5.x and npm'
 

--- a/deb/setup_5.x
+++ b/deb/setup_5.x
@@ -14,6 +14,10 @@
 #
 
 export DEBIAN_FRONTEND=noninteractive
+SCRSUFFIX="_5.x"
+NODENAME="Node.js v5.x"
+NODEREPO="node_5.x"
+NODEPKG="nodejs"
 
 print_status() {
     echo
@@ -71,10 +75,10 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "XNode.js v5.x" == "XNode.js v0.10" ]; then
+    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v5.x will cease to be actively supported in ${bold}October 2016${normal}.
+Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -99,10 +103,10 @@ Node.js v5.x will cease to be actively supported in ${bold}October 2016${normal}
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
-    elif [ "XNode.js v5.x" == "XNode.js v0.12" ]; then
+    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v5.x will cease to be actively supported ${bold}at the end of 2016${normal}.
+Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -131,11 +135,11 @@ Node.js v5.x will cease to be actively supported ${bold}at the end of 2016${norm
 }
 
 script_deprecation_warning() {
-    if [ "X_5.x" == "X" ]; then
+    if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
 "                            DEPRECATION WARNING                            " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v5.x, is being deprecated and will eventually be made
+  install Node.js v0.10, is being deprecated and will eventually be made
   inactive.
 
   You should use the script that corresponds to the version of Node.js you
@@ -164,7 +168,7 @@ setup() {
 
 script_deprecation_warning
 
-print_status "Installing the NodeSource Node.js v5.x repo..."
+print_status "Installing the NodeSource ${NODENAME} repo..."
 
 
 PRE_INSTALL_PKGS=""
@@ -237,10 +241,10 @@ fi
 print_status "Confirming \"${DISTRO}\" is supported..."
 
 if [ -x /usr/bin/curl ]; then
-    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/node_5.x/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 else
-    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/node_5.x/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 fi
 
@@ -264,10 +268,10 @@ else
     exec_cmd 'wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -'
 fi
 
-print_status 'Creating apt sources list file for the NodeSource Node.js v5.x repo...'
+print_status 'Creating apt sources list file for the NodeSource ${NODENAME} repo...'
 
-exec_cmd "echo 'deb https://deb.nodesource.com/node_5.x ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
-exec_cmd "echo 'deb-src https://deb.nodesource.com/node_5.x ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb-src https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
 
 print_status 'Running `apt-get update` for you...'
 
@@ -275,7 +279,7 @@ exec_cmd 'apt-get update'
 
 node_deprecation_warning
 
-print_status 'Run `apt-get install nodejs` (as root) to install Node.js v5.x and npm'
+print_status 'Run `apt-get install ${NODEPKG}` (as root) to install ${NODENAME} and npm'
 
 }
 

--- a/deb/setup_5.x
+++ b/deb/setup_5.x
@@ -75,7 +75,39 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
+          "X${NODENAME}" == "Xio.js v2.x" ||
+          "X${NODENAME}" == "Xio.js v3.x" ||
+          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+${bold}${NODENAME} is no longer actively supported!${normal}
+
+  ${bold}You will not receive security or critical stability updates${normal} for this version.
+
+  You should migrate to a supported version of Node.js as soon as possible.
+  Use the installation script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+        echo
+        echo "Continuing in 10 seconds ..."
+        echo
+        sleep 10
+
+    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
 Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
@@ -103,7 +135,9 @@ Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
+
     elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
+
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
 Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
@@ -131,13 +165,14 @@ Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${nor
         echo "Continuing in 3 seconds ..."
         echo
         sleep 3
+
     fi
 }
 
 script_deprecation_warning() {
     if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
-"                            DEPRECATION WARNING                            " "\
+"                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
   install Node.js v0.10, is being deprecated and will eventually be made
   inactive.

--- a/deb/setup_6.x
+++ b/deb/setup_6.x
@@ -14,6 +14,10 @@
 #
 
 export DEBIAN_FRONTEND=noninteractive
+SCRSUFFIX="_6.x"
+NODENAME="Node.js v6.x"
+NODEREPO="node_6.x"
+NODEPKG="nodejs"
 
 print_status() {
     echo
@@ -71,10 +75,10 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "XNode.js v6.x" == "XNode.js v0.10" ]; then
+    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v6.x will cease to be actively supported in ${bold}October 2016${normal}.
+Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -99,10 +103,10 @@ Node.js v6.x will cease to be actively supported in ${bold}October 2016${normal}
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
-    elif [ "XNode.js v6.x" == "XNode.js v0.12" ]; then
+    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v6.x will cease to be actively supported ${bold}at the end of 2016${normal}.
+Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -131,11 +135,11 @@ Node.js v6.x will cease to be actively supported ${bold}at the end of 2016${norm
 }
 
 script_deprecation_warning() {
-    if [ "X_6.x" == "X" ]; then
+    if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
 "                            DEPRECATION WARNING                            " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v6.x, is being deprecated and will eventually be made
+  install Node.js v0.10, is being deprecated and will eventually be made
   inactive.
 
   You should use the script that corresponds to the version of Node.js you
@@ -164,7 +168,7 @@ setup() {
 
 script_deprecation_warning
 
-print_status "Installing the NodeSource Node.js v6.x repo..."
+print_status "Installing the NodeSource ${NODENAME} repo..."
 
 
 PRE_INSTALL_PKGS=""
@@ -237,10 +241,10 @@ fi
 print_status "Confirming \"${DISTRO}\" is supported..."
 
 if [ -x /usr/bin/curl ]; then
-    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/node_6.x/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 else
-    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/node_6.x/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 fi
 
@@ -264,10 +268,10 @@ else
     exec_cmd 'wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -'
 fi
 
-print_status 'Creating apt sources list file for the NodeSource Node.js v6.x repo...'
+print_status 'Creating apt sources list file for the NodeSource ${NODENAME} repo...'
 
-exec_cmd "echo 'deb https://deb.nodesource.com/node_6.x ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
-exec_cmd "echo 'deb-src https://deb.nodesource.com/node_6.x ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb-src https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
 
 print_status 'Running `apt-get update` for you...'
 
@@ -275,7 +279,7 @@ exec_cmd 'apt-get update'
 
 node_deprecation_warning
 
-print_status 'Run `apt-get install nodejs` (as root) to install Node.js v6.x and npm'
+print_status 'Run `apt-get install ${NODEPKG}` (as root) to install ${NODENAME} and npm'
 
 }
 

--- a/deb/setup_6.x
+++ b/deb/setup_6.x
@@ -21,6 +21,41 @@ print_status() {
     echo
 }
 
+if test -t 1; then # if terminal
+    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        termcols=$(tput cols)
+        bold="$(tput bold)"
+        underline="$(tput smul)"
+        standout="$(tput smso)"
+        normal="$(tput sgr0)"
+        black="$(tput setaf 0)"
+        red="$(tput setaf 1)"
+        green="$(tput setaf 2)"
+        yellow="$(tput setaf 3)"
+        blue="$(tput setaf 4)"
+        magenta="$(tput setaf 5)"
+        cyan="$(tput setaf 6)"
+        white="$(tput setaf 7)"
+    fi
+fi
+
+print_bold() {
+    title="$1"
+    text="$2"
+
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+    echo
+    echo -e "  ${bold}${yellow}${title}${normal}"
+    echo
+    echo -en "  ${text}"
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+}
+
 bail() {
     echo 'Error executing command, exiting'
     exit 1
@@ -35,8 +70,99 @@ exec_cmd() {
     exec_cmd_nobail "$1" || bail
 }
 
+node_deprecation_warning() {
+    if [ "XNode.js v6.x" == "XNode.js v0.10" ]; then
+        print_bold \
+"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
+Node.js v6.x will cease to be actively supported in ${bold}October 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 5 seconds ..."
+        echo
+        sleep 5
+    elif [ "XNode.js v6.x" == "XNode.js v0.12" ]; then
+        print_bold \
+"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
+Node.js v6.x will cease to be actively supported ${bold}at the end of 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 3 seconds ..."
+        echo
+        sleep 3
+    fi
+}
+
+script_deprecation_warning() {
+    if [ "X_6.x" == "X" ]; then
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
+  install Node.js v6.x, is being deprecated and will eventually be made
+  inactive.
+
+  You should use the script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo
+        sleep 10
+    fi
+}
 
 setup() {
+
+script_deprecation_warning
 
 print_status "Installing the NodeSource Node.js v6.x repo..."
 
@@ -146,6 +272,8 @@ exec_cmd "echo 'deb-src https://deb.nodesource.com/node_6.x ${DISTRO} main' >> /
 print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
+
+node_deprecation_warning
 
 print_status 'Run `apt-get install nodejs` (as root) to install Node.js v6.x and npm'
 

--- a/deb/setup_6.x
+++ b/deb/setup_6.x
@@ -75,7 +75,39 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
+          "X${NODENAME}" == "Xio.js v2.x" ||
+          "X${NODENAME}" == "Xio.js v3.x" ||
+          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+${bold}${NODENAME} is no longer actively supported!${normal}
+
+  ${bold}You will not receive security or critical stability updates${normal} for this version.
+
+  You should migrate to a supported version of Node.js as soon as possible.
+  Use the installation script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+        echo
+        echo "Continuing in 10 seconds ..."
+        echo
+        sleep 10
+
+    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
 Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
@@ -103,7 +135,9 @@ Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
+
     elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
+
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
 Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
@@ -131,13 +165,14 @@ Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${nor
         echo "Continuing in 3 seconds ..."
         echo
         sleep 3
+
     fi
 }
 
 script_deprecation_warning() {
     if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
-"                            DEPRECATION WARNING                            " "\
+"                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
   install Node.js v0.10, is being deprecated and will eventually be made
   inactive.

--- a/deb/setup_dev
+++ b/deb/setup_dev
@@ -14,6 +14,10 @@
 #
 
 export DEBIAN_FRONTEND=noninteractive
+SCRSUFFIX="_dev"
+NODENAME="Node.js v0.12"
+NODEREPO="node_0.12"
+NODEPKG="nodejs"
 
 print_status() {
     echo
@@ -71,10 +75,10 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "XNode.js v0.12" == "XNode.js v0.10" ]; then
+    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported in ${bold}October 2016${normal}.
+Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -99,7 +103,7 @@ Node.js v0.12 will cease to be actively supported in ${bold}October 2016${normal
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
-    elif [ "XNode.js v0.12" == "XNode.js v0.12" ]; then
+    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
 Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
@@ -131,11 +135,11 @@ Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${nor
 }
 
 script_deprecation_warning() {
-    if [ "X_dev" == "X" ]; then
+    if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
 "                            DEPRECATION WARNING                            " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v0.12, is being deprecated and will eventually be made
+  install Node.js v0.10, is being deprecated and will eventually be made
   inactive.
 
   You should use the script that corresponds to the version of Node.js you
@@ -164,7 +168,7 @@ setup() {
 
 script_deprecation_warning
 
-print_status "Installing the NodeSource Node.js v0.12 repo..."
+print_status "Installing the NodeSource ${NODENAME} repo..."
 
 
 PRE_INSTALL_PKGS=""
@@ -237,10 +241,10 @@ fi
 print_status "Confirming \"${DISTRO}\" is supported..."
 
 if [ -x /usr/bin/curl ]; then
-    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/node_0.12/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 else
-    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/node_0.12/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 fi
 
@@ -264,10 +268,10 @@ else
     exec_cmd 'wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -'
 fi
 
-print_status 'Creating apt sources list file for the NodeSource Node.js v0.12 repo...'
+print_status 'Creating apt sources list file for the NodeSource ${NODENAME} repo...'
 
-exec_cmd "echo 'deb https://deb.nodesource.com/node_0.12 ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
-exec_cmd "echo 'deb-src https://deb.nodesource.com/node_0.12 ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb-src https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
 
 print_status 'Running `apt-get update` for you...'
 
@@ -275,7 +279,7 @@ exec_cmd 'apt-get update'
 
 node_deprecation_warning
 
-print_status 'Run `apt-get install nodejs` (as root) to install Node.js v0.12 and npm'
+print_status 'Run `apt-get install ${NODEPKG}` (as root) to install ${NODENAME} and npm'
 
 }
 

--- a/deb/setup_dev
+++ b/deb/setup_dev
@@ -21,6 +21,41 @@ print_status() {
     echo
 }
 
+if test -t 1; then # if terminal
+    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        termcols=$(tput cols)
+        bold="$(tput bold)"
+        underline="$(tput smul)"
+        standout="$(tput smso)"
+        normal="$(tput sgr0)"
+        black="$(tput setaf 0)"
+        red="$(tput setaf 1)"
+        green="$(tput setaf 2)"
+        yellow="$(tput setaf 3)"
+        blue="$(tput setaf 4)"
+        magenta="$(tput setaf 5)"
+        cyan="$(tput setaf 6)"
+        white="$(tput setaf 7)"
+    fi
+fi
+
+print_bold() {
+    title="$1"
+    text="$2"
+
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+    echo
+    echo -e "  ${bold}${yellow}${title}${normal}"
+    echo
+    echo -en "  ${text}"
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+}
+
 bail() {
     echo 'Error executing command, exiting'
     exit 1
@@ -35,8 +70,99 @@ exec_cmd() {
     exec_cmd_nobail "$1" || bail
 }
 
+node_deprecation_warning() {
+    if [ "XNode.js v0.12" == "XNode.js v0.10" ]; then
+        print_bold \
+"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
+Node.js v0.12 will cease to be actively supported in ${bold}October 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 5 seconds ..."
+        echo
+        sleep 5
+    elif [ "XNode.js v0.12" == "XNode.js v0.12" ]; then
+        print_bold \
+"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
+Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 3 seconds ..."
+        echo
+        sleep 3
+    fi
+}
+
+script_deprecation_warning() {
+    if [ "X_dev" == "X" ]; then
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
+  install Node.js v0.12, is being deprecated and will eventually be made
+  inactive.
+
+  You should use the script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo
+        sleep 10
+    fi
+}
 
 setup() {
+
+script_deprecation_warning
 
 print_status "Installing the NodeSource Node.js v0.12 repo..."
 
@@ -146,6 +272,8 @@ exec_cmd "echo 'deb-src https://deb.nodesource.com/node_0.12 ${DISTRO} main' >> 
 print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
+
+node_deprecation_warning
 
 print_status 'Run `apt-get install nodejs` (as root) to install Node.js v0.12 and npm'
 

--- a/deb/setup_dev
+++ b/deb/setup_dev
@@ -75,7 +75,39 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
+          "X${NODENAME}" == "Xio.js v2.x" ||
+          "X${NODENAME}" == "Xio.js v3.x" ||
+          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+${bold}${NODENAME} is no longer actively supported!${normal}
+
+  ${bold}You will not receive security or critical stability updates${normal} for this version.
+
+  You should migrate to a supported version of Node.js as soon as possible.
+  Use the installation script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+        echo
+        echo "Continuing in 10 seconds ..."
+        echo
+        sleep 10
+
+    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
 Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
@@ -103,7 +135,9 @@ Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
+
     elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
+
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
 Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
@@ -131,13 +165,14 @@ Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${nor
         echo "Continuing in 3 seconds ..."
         echo
         sleep 3
+
     fi
 }
 
 script_deprecation_warning() {
     if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
-"                            DEPRECATION WARNING                            " "\
+"                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
   install Node.js v0.10, is being deprecated and will eventually be made
   inactive.

--- a/deb/setup_iojs_1.x
+++ b/deb/setup_iojs_1.x
@@ -14,6 +14,10 @@
 #
 
 export DEBIAN_FRONTEND=noninteractive
+SCRSUFFIX="_iojs_1.x"
+NODENAME="io.js v1.x"
+NODEREPO="iojs_1.x"
+NODEPKG="iojs"
 
 print_status() {
     echo
@@ -71,10 +75,10 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "Xio.js v1.x" == "XNode.js v0.10" ]; then
+    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-io.js v1.x will cease to be actively supported in ${bold}October 2016${normal}.
+Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -99,10 +103,10 @@ io.js v1.x will cease to be actively supported in ${bold}October 2016${normal}.
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
-    elif [ "Xio.js v1.x" == "XNode.js v0.12" ]; then
+    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-io.js v1.x will cease to be actively supported ${bold}at the end of 2016${normal}.
+Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -131,11 +135,11 @@ io.js v1.x will cease to be actively supported ${bold}at the end of 2016${normal
 }
 
 script_deprecation_warning() {
-    if [ "X_iojs_1.x" == "X" ]; then
+    if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
 "                            DEPRECATION WARNING                            " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install io.js v1.x, is being deprecated and will eventually be made
+  install Node.js v0.10, is being deprecated and will eventually be made
   inactive.
 
   You should use the script that corresponds to the version of Node.js you
@@ -164,7 +168,7 @@ setup() {
 
 script_deprecation_warning
 
-print_status "Installing the NodeSource io.js v1.x repo..."
+print_status "Installing the NodeSource ${NODENAME} repo..."
 
 
 PRE_INSTALL_PKGS=""
@@ -237,10 +241,10 @@ fi
 print_status "Confirming \"${DISTRO}\" is supported..."
 
 if [ -x /usr/bin/curl ]; then
-    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/iojs_1.x/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 else
-    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/iojs_1.x/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 fi
 
@@ -264,10 +268,10 @@ else
     exec_cmd 'wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -'
 fi
 
-print_status 'Creating apt sources list file for the NodeSource io.js v1.x repo...'
+print_status 'Creating apt sources list file for the NodeSource ${NODENAME} repo...'
 
-exec_cmd "echo 'deb https://deb.nodesource.com/iojs_1.x ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
-exec_cmd "echo 'deb-src https://deb.nodesource.com/iojs_1.x ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb-src https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
 
 print_status 'Running `apt-get update` for you...'
 
@@ -275,7 +279,7 @@ exec_cmd 'apt-get update'
 
 node_deprecation_warning
 
-print_status 'Run `apt-get install iojs` (as root) to install io.js v1.x and npm'
+print_status 'Run `apt-get install ${NODEPKG}` (as root) to install ${NODENAME} and npm'
 
 }
 

--- a/deb/setup_iojs_1.x
+++ b/deb/setup_iojs_1.x
@@ -21,6 +21,41 @@ print_status() {
     echo
 }
 
+if test -t 1; then # if terminal
+    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        termcols=$(tput cols)
+        bold="$(tput bold)"
+        underline="$(tput smul)"
+        standout="$(tput smso)"
+        normal="$(tput sgr0)"
+        black="$(tput setaf 0)"
+        red="$(tput setaf 1)"
+        green="$(tput setaf 2)"
+        yellow="$(tput setaf 3)"
+        blue="$(tput setaf 4)"
+        magenta="$(tput setaf 5)"
+        cyan="$(tput setaf 6)"
+        white="$(tput setaf 7)"
+    fi
+fi
+
+print_bold() {
+    title="$1"
+    text="$2"
+
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+    echo
+    echo -e "  ${bold}${yellow}${title}${normal}"
+    echo
+    echo -en "  ${text}"
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+}
+
 bail() {
     echo 'Error executing command, exiting'
     exit 1
@@ -35,8 +70,99 @@ exec_cmd() {
     exec_cmd_nobail "$1" || bail
 }
 
+node_deprecation_warning() {
+    if [ "Xio.js v1.x" == "XNode.js v0.10" ]; then
+        print_bold \
+"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
+io.js v1.x will cease to be actively supported in ${bold}October 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 5 seconds ..."
+        echo
+        sleep 5
+    elif [ "Xio.js v1.x" == "XNode.js v0.12" ]; then
+        print_bold \
+"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
+io.js v1.x will cease to be actively supported ${bold}at the end of 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 3 seconds ..."
+        echo
+        sleep 3
+    fi
+}
+
+script_deprecation_warning() {
+    if [ "X_iojs_1.x" == "X" ]; then
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
+  install io.js v1.x, is being deprecated and will eventually be made
+  inactive.
+
+  You should use the script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo
+        sleep 10
+    fi
+}
 
 setup() {
+
+script_deprecation_warning
 
 print_status "Installing the NodeSource io.js v1.x repo..."
 
@@ -146,6 +272,8 @@ exec_cmd "echo 'deb-src https://deb.nodesource.com/iojs_1.x ${DISTRO} main' >> /
 print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
+
+node_deprecation_warning
 
 print_status 'Run `apt-get install iojs` (as root) to install io.js v1.x and npm'
 

--- a/deb/setup_iojs_1.x
+++ b/deb/setup_iojs_1.x
@@ -75,7 +75,39 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
+          "X${NODENAME}" == "Xio.js v2.x" ||
+          "X${NODENAME}" == "Xio.js v3.x" ||
+          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+${bold}${NODENAME} is no longer actively supported!${normal}
+
+  ${bold}You will not receive security or critical stability updates${normal} for this version.
+
+  You should migrate to a supported version of Node.js as soon as possible.
+  Use the installation script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+        echo
+        echo "Continuing in 10 seconds ..."
+        echo
+        sleep 10
+
+    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
 Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
@@ -103,7 +135,9 @@ Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
+
     elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
+
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
 Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
@@ -131,13 +165,14 @@ Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${nor
         echo "Continuing in 3 seconds ..."
         echo
         sleep 3
+
     fi
 }
 
 script_deprecation_warning() {
     if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
-"                            DEPRECATION WARNING                            " "\
+"                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
   install Node.js v0.10, is being deprecated and will eventually be made
   inactive.

--- a/deb/setup_iojs_2.x
+++ b/deb/setup_iojs_2.x
@@ -14,6 +14,10 @@
 #
 
 export DEBIAN_FRONTEND=noninteractive
+SCRSUFFIX="_iojs_2.x"
+NODENAME="io.js v2.x"
+NODEREPO="iojs_2.x"
+NODEPKG="iojs"
 
 print_status() {
     echo
@@ -71,10 +75,10 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "Xio.js v2.x" == "XNode.js v0.10" ]; then
+    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-io.js v2.x will cease to be actively supported in ${bold}October 2016${normal}.
+Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -99,10 +103,10 @@ io.js v2.x will cease to be actively supported in ${bold}October 2016${normal}.
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
-    elif [ "Xio.js v2.x" == "XNode.js v0.12" ]; then
+    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-io.js v2.x will cease to be actively supported ${bold}at the end of 2016${normal}.
+Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -131,11 +135,11 @@ io.js v2.x will cease to be actively supported ${bold}at the end of 2016${normal
 }
 
 script_deprecation_warning() {
-    if [ "X_iojs_2.x" == "X" ]; then
+    if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
 "                            DEPRECATION WARNING                            " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install io.js v2.x, is being deprecated and will eventually be made
+  install Node.js v0.10, is being deprecated and will eventually be made
   inactive.
 
   You should use the script that corresponds to the version of Node.js you
@@ -164,7 +168,7 @@ setup() {
 
 script_deprecation_warning
 
-print_status "Installing the NodeSource io.js v2.x repo..."
+print_status "Installing the NodeSource ${NODENAME} repo..."
 
 
 PRE_INSTALL_PKGS=""
@@ -237,10 +241,10 @@ fi
 print_status "Confirming \"${DISTRO}\" is supported..."
 
 if [ -x /usr/bin/curl ]; then
-    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/iojs_2.x/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 else
-    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/iojs_2.x/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 fi
 
@@ -264,10 +268,10 @@ else
     exec_cmd 'wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -'
 fi
 
-print_status 'Creating apt sources list file for the NodeSource io.js v2.x repo...'
+print_status 'Creating apt sources list file for the NodeSource ${NODENAME} repo...'
 
-exec_cmd "echo 'deb https://deb.nodesource.com/iojs_2.x ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
-exec_cmd "echo 'deb-src https://deb.nodesource.com/iojs_2.x ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb-src https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
 
 print_status 'Running `apt-get update` for you...'
 
@@ -275,7 +279,7 @@ exec_cmd 'apt-get update'
 
 node_deprecation_warning
 
-print_status 'Run `apt-get install iojs` (as root) to install io.js v2.x and npm'
+print_status 'Run `apt-get install ${NODEPKG}` (as root) to install ${NODENAME} and npm'
 
 }
 

--- a/deb/setup_iojs_2.x
+++ b/deb/setup_iojs_2.x
@@ -21,6 +21,41 @@ print_status() {
     echo
 }
 
+if test -t 1; then # if terminal
+    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        termcols=$(tput cols)
+        bold="$(tput bold)"
+        underline="$(tput smul)"
+        standout="$(tput smso)"
+        normal="$(tput sgr0)"
+        black="$(tput setaf 0)"
+        red="$(tput setaf 1)"
+        green="$(tput setaf 2)"
+        yellow="$(tput setaf 3)"
+        blue="$(tput setaf 4)"
+        magenta="$(tput setaf 5)"
+        cyan="$(tput setaf 6)"
+        white="$(tput setaf 7)"
+    fi
+fi
+
+print_bold() {
+    title="$1"
+    text="$2"
+
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+    echo
+    echo -e "  ${bold}${yellow}${title}${normal}"
+    echo
+    echo -en "  ${text}"
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+}
+
 bail() {
     echo 'Error executing command, exiting'
     exit 1
@@ -35,8 +70,99 @@ exec_cmd() {
     exec_cmd_nobail "$1" || bail
 }
 
+node_deprecation_warning() {
+    if [ "Xio.js v2.x" == "XNode.js v0.10" ]; then
+        print_bold \
+"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
+io.js v2.x will cease to be actively supported in ${bold}October 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 5 seconds ..."
+        echo
+        sleep 5
+    elif [ "Xio.js v2.x" == "XNode.js v0.12" ]; then
+        print_bold \
+"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
+io.js v2.x will cease to be actively supported ${bold}at the end of 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 3 seconds ..."
+        echo
+        sleep 3
+    fi
+}
+
+script_deprecation_warning() {
+    if [ "X_iojs_2.x" == "X" ]; then
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
+  install io.js v2.x, is being deprecated and will eventually be made
+  inactive.
+
+  You should use the script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo
+        sleep 10
+    fi
+}
 
 setup() {
+
+script_deprecation_warning
 
 print_status "Installing the NodeSource io.js v2.x repo..."
 
@@ -146,6 +272,8 @@ exec_cmd "echo 'deb-src https://deb.nodesource.com/iojs_2.x ${DISTRO} main' >> /
 print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
+
+node_deprecation_warning
 
 print_status 'Run `apt-get install iojs` (as root) to install io.js v2.x and npm'
 

--- a/deb/setup_iojs_2.x
+++ b/deb/setup_iojs_2.x
@@ -75,7 +75,39 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
+          "X${NODENAME}" == "Xio.js v2.x" ||
+          "X${NODENAME}" == "Xio.js v3.x" ||
+          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+${bold}${NODENAME} is no longer actively supported!${normal}
+
+  ${bold}You will not receive security or critical stability updates${normal} for this version.
+
+  You should migrate to a supported version of Node.js as soon as possible.
+  Use the installation script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+        echo
+        echo "Continuing in 10 seconds ..."
+        echo
+        sleep 10
+
+    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
 Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
@@ -103,7 +135,9 @@ Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
+
     elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
+
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
 Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
@@ -131,13 +165,14 @@ Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${nor
         echo "Continuing in 3 seconds ..."
         echo
         sleep 3
+
     fi
 }
 
 script_deprecation_warning() {
     if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
-"                            DEPRECATION WARNING                            " "\
+"                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
   install Node.js v0.10, is being deprecated and will eventually be made
   inactive.

--- a/deb/setup_iojs_3.x
+++ b/deb/setup_iojs_3.x
@@ -14,6 +14,10 @@
 #
 
 export DEBIAN_FRONTEND=noninteractive
+SCRSUFFIX="_iojs_3.x"
+NODENAME="io.js v3.x"
+NODEREPO="iojs_3.x"
+NODEPKG="iojs"
 
 print_status() {
     echo
@@ -71,10 +75,10 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "Xio.js v3.x" == "XNode.js v0.10" ]; then
+    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-io.js v3.x will cease to be actively supported in ${bold}October 2016${normal}.
+Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -99,10 +103,10 @@ io.js v3.x will cease to be actively supported in ${bold}October 2016${normal}.
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
-    elif [ "Xio.js v3.x" == "XNode.js v0.12" ]; then
+    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-io.js v3.x will cease to be actively supported ${bold}at the end of 2016${normal}.
+Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -131,11 +135,11 @@ io.js v3.x will cease to be actively supported ${bold}at the end of 2016${normal
 }
 
 script_deprecation_warning() {
-    if [ "X_iojs_3.x" == "X" ]; then
+    if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
 "                            DEPRECATION WARNING                            " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install io.js v3.x, is being deprecated and will eventually be made
+  install Node.js v0.10, is being deprecated and will eventually be made
   inactive.
 
   You should use the script that corresponds to the version of Node.js you
@@ -164,7 +168,7 @@ setup() {
 
 script_deprecation_warning
 
-print_status "Installing the NodeSource io.js v3.x repo..."
+print_status "Installing the NodeSource ${NODENAME} repo..."
 
 
 PRE_INSTALL_PKGS=""
@@ -237,10 +241,10 @@ fi
 print_status "Confirming \"${DISTRO}\" is supported..."
 
 if [ -x /usr/bin/curl ]; then
-    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/iojs_3.x/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 else
-    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/iojs_3.x/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 fi
 
@@ -264,10 +268,10 @@ else
     exec_cmd 'wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -'
 fi
 
-print_status 'Creating apt sources list file for the NodeSource io.js v3.x repo...'
+print_status 'Creating apt sources list file for the NodeSource ${NODENAME} repo...'
 
-exec_cmd "echo 'deb https://deb.nodesource.com/iojs_3.x ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
-exec_cmd "echo 'deb-src https://deb.nodesource.com/iojs_3.x ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb-src https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
 
 print_status 'Running `apt-get update` for you...'
 
@@ -275,7 +279,7 @@ exec_cmd 'apt-get update'
 
 node_deprecation_warning
 
-print_status 'Run `apt-get install iojs` (as root) to install io.js v3.x and npm'
+print_status 'Run `apt-get install ${NODEPKG}` (as root) to install ${NODENAME} and npm'
 
 }
 

--- a/deb/setup_iojs_3.x
+++ b/deb/setup_iojs_3.x
@@ -75,7 +75,39 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
+          "X${NODENAME}" == "Xio.js v2.x" ||
+          "X${NODENAME}" == "Xio.js v3.x" ||
+          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+${bold}${NODENAME} is no longer actively supported!${normal}
+
+  ${bold}You will not receive security or critical stability updates${normal} for this version.
+
+  You should migrate to a supported version of Node.js as soon as possible.
+  Use the installation script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+        echo
+        echo "Continuing in 10 seconds ..."
+        echo
+        sleep 10
+
+    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
 Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
@@ -103,7 +135,9 @@ Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
+
     elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
+
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
 Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
@@ -131,13 +165,14 @@ Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${nor
         echo "Continuing in 3 seconds ..."
         echo
         sleep 3
+
     fi
 }
 
 script_deprecation_warning() {
     if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
-"                            DEPRECATION WARNING                            " "\
+"                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
   install Node.js v0.10, is being deprecated and will eventually be made
   inactive.

--- a/deb/setup_iojs_3.x
+++ b/deb/setup_iojs_3.x
@@ -21,6 +21,41 @@ print_status() {
     echo
 }
 
+if test -t 1; then # if terminal
+    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        termcols=$(tput cols)
+        bold="$(tput bold)"
+        underline="$(tput smul)"
+        standout="$(tput smso)"
+        normal="$(tput sgr0)"
+        black="$(tput setaf 0)"
+        red="$(tput setaf 1)"
+        green="$(tput setaf 2)"
+        yellow="$(tput setaf 3)"
+        blue="$(tput setaf 4)"
+        magenta="$(tput setaf 5)"
+        cyan="$(tput setaf 6)"
+        white="$(tput setaf 7)"
+    fi
+fi
+
+print_bold() {
+    title="$1"
+    text="$2"
+
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+    echo
+    echo -e "  ${bold}${yellow}${title}${normal}"
+    echo
+    echo -en "  ${text}"
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+}
+
 bail() {
     echo 'Error executing command, exiting'
     exit 1
@@ -35,8 +70,99 @@ exec_cmd() {
     exec_cmd_nobail "$1" || bail
 }
 
+node_deprecation_warning() {
+    if [ "Xio.js v3.x" == "XNode.js v0.10" ]; then
+        print_bold \
+"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
+io.js v3.x will cease to be actively supported in ${bold}October 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 5 seconds ..."
+        echo
+        sleep 5
+    elif [ "Xio.js v3.x" == "XNode.js v0.12" ]; then
+        print_bold \
+"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
+io.js v3.x will cease to be actively supported ${bold}at the end of 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 3 seconds ..."
+        echo
+        sleep 3
+    fi
+}
+
+script_deprecation_warning() {
+    if [ "X_iojs_3.x" == "X" ]; then
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
+  install io.js v3.x, is being deprecated and will eventually be made
+  inactive.
+
+  You should use the script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo
+        sleep 10
+    fi
+}
 
 setup() {
+
+script_deprecation_warning
 
 print_status "Installing the NodeSource io.js v3.x repo..."
 
@@ -146,6 +272,8 @@ exec_cmd "echo 'deb-src https://deb.nodesource.com/iojs_3.x ${DISTRO} main' >> /
 print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
+
+node_deprecation_warning
 
 print_status 'Run `apt-get install iojs` (as root) to install io.js v3.x and npm'
 

--- a/deb/src/_setup.sh
+++ b/deb/src/_setup.sh
@@ -14,6 +14,10 @@
 #
 
 export DEBIAN_FRONTEND=noninteractive
+SCRSUFFIX="{{suffix}}"
+NODENAME="{{name}}"
+NODEREPO="{{repo}}"
+NODEPKG="{{package}}"
 
 print_status() {
     echo
@@ -71,10 +75,10 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "X{{name}}" == "XNode.js v0.10" ]; then
+    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-{{name}} will cease to be actively supported in ${bold}October 2016${normal}.
+Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -99,10 +103,10 @@ node_deprecation_warning() {
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
-    elif [ "X{{name}}" == "XNode.js v0.12" ]; then
+    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-{{name}} will cease to be actively supported ${bold}at the end of 2016${normal}.
+Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -131,11 +135,11 @@ node_deprecation_warning() {
 }
 
 script_deprecation_warning() {
-    if [ "X{{suffix}}" == "X" ]; then
+    if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
 "                            DEPRECATION WARNING                            " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install {{name}}, is being deprecated and will eventually be made
+  install Node.js v0.10, is being deprecated and will eventually be made
   inactive.
 
   You should use the script that corresponds to the version of Node.js you
@@ -164,7 +168,7 @@ setup() {
 
 script_deprecation_warning
 
-print_status "Installing the NodeSource {{name}} repo..."
+print_status "Installing the NodeSource ${NODENAME} repo..."
 
 
 PRE_INSTALL_PKGS=""
@@ -237,10 +241,10 @@ fi
 print_status "Confirming \"${DISTRO}\" is supported..."
 
 if [ -x /usr/bin/curl ]; then
-    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/{{repo}}/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 else
-    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/{{repo}}/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/${NODEREPO}/dists/${DISTRO}/Release'"
     RC=$?
 fi
 
@@ -264,10 +268,10 @@ else
     exec_cmd 'wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -'
 fi
 
-print_status 'Creating apt sources list file for the NodeSource {{name}} repo...'
+print_status 'Creating apt sources list file for the NodeSource ${NODENAME} repo...'
 
-exec_cmd "echo 'deb https://deb.nodesource.com/{{repo}} ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
-exec_cmd "echo 'deb-src https://deb.nodesource.com/{{repo}} ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb-src https://deb.nodesource.com/${NODEREPO} ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
 
 print_status 'Running `apt-get update` for you...'
 
@@ -275,7 +279,7 @@ exec_cmd 'apt-get update'
 
 node_deprecation_warning
 
-print_status 'Run `apt-get install {{package}}` (as root) to install {{name}} and npm'
+print_status 'Run `apt-get install ${NODEPKG}` (as root) to install ${NODENAME} and npm'
 
 }
 

--- a/deb/src/_setup.sh
+++ b/deb/src/_setup.sh
@@ -21,6 +21,41 @@ print_status() {
     echo
 }
 
+if test -t 1; then # if terminal
+    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        termcols=$(tput cols)
+        bold="$(tput bold)"
+        underline="$(tput smul)"
+        standout="$(tput smso)"
+        normal="$(tput sgr0)"
+        black="$(tput setaf 0)"
+        red="$(tput setaf 1)"
+        green="$(tput setaf 2)"
+        yellow="$(tput setaf 3)"
+        blue="$(tput setaf 4)"
+        magenta="$(tput setaf 5)"
+        cyan="$(tput setaf 6)"
+        white="$(tput setaf 7)"
+    fi
+fi
+
+print_bold() {
+    title="$1"
+    text="$2"
+
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+    echo
+    echo -e "  ${bold}${yellow}${title}${normal}"
+    echo
+    echo -en "  ${text}"
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+}
+
 bail() {
     echo 'Error executing command, exiting'
     exit 1
@@ -35,8 +70,99 @@ exec_cmd() {
     exec_cmd_nobail "$1" || bail
 }
 
+node_deprecation_warning() {
+    if [ "X{{name}}" == "XNode.js v0.10" ]; then
+        print_bold \
+"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
+{{name}} will cease to be actively supported in ${bold}October 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 5 seconds ..."
+        echo
+        sleep 5
+    elif [ "X{{name}}" == "XNode.js v0.12" ]; then
+        print_bold \
+"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
+{{name}} will cease to be actively supported ${bold}at the end of 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 3 seconds ..."
+        echo
+        sleep 3
+    fi
+}
+
+script_deprecation_warning() {
+    if [ "X{{suffix}}" == "X" ]; then
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
+  install {{name}}, is being deprecated and will eventually be made
+  inactive.
+
+  You should use the script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo
+        sleep 10
+    fi
+}
 
 setup() {
+
+script_deprecation_warning
 
 print_status "Installing the NodeSource {{name}} repo..."
 
@@ -146,6 +272,8 @@ exec_cmd "echo 'deb-src https://deb.nodesource.com/{{repo}} ${DISTRO} main' >> /
 print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
+
+node_deprecation_warning
 
 print_status 'Run `apt-get install {{package}}` (as root) to install {{name}} and npm'
 

--- a/deb/src/_setup.sh
+++ b/deb/src/_setup.sh
@@ -75,7 +75,39 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
+          "X${NODENAME}" == "Xio.js v2.x" ||
+          "X${NODENAME}" == "Xio.js v3.x" ||
+          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+${bold}${NODENAME} is no longer actively supported!${normal}
+
+  ${bold}You will not receive security or critical stability updates${normal} for this version.
+
+  You should migrate to a supported version of Node.js as soon as possible.
+  Use the installation script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+        echo
+        echo "Continuing in 10 seconds ..."
+        echo
+        sleep 10
+
+    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
+
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
 Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
@@ -103,7 +135,9 @@ Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
+
     elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
+
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
 Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
@@ -131,13 +165,14 @@ Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${nor
         echo "Continuing in 3 seconds ..."
         echo
         sleep 3
+
     fi
 }
 
 script_deprecation_warning() {
     if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
-"                            DEPRECATION WARNING                            " "\
+"                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
   install Node.js v0.10, is being deprecated and will eventually be made
   inactive.

--- a/rpm/setup
+++ b/rpm/setup
@@ -13,6 +13,11 @@
 # wget -qO- https://rpm.nodesource.com/setup | bash -
 #
 
+SCRSUFFIX=""
+NODENAME="Node.js 0.10"
+NODEREPO="pub_0.10"
+NODEPKG="nodejs"
+
 print_status() {
   local outp=$(echo "$1" | sed -r 's/\\n/\\n## /mg')
   echo
@@ -70,10 +75,10 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "XNode.js 0.10" == "XNode.js v0.10" ]; then
+    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js 0.10 will cease to be actively supported in ${bold}October 2016${normal}.
+Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -98,10 +103,10 @@ Node.js 0.10 will cease to be actively supported in ${bold}October 2016${normal}
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
-    elif [ "XNode.js 0.10" == "XNode.js v0.12" ]; then
+    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js 0.10 will cease to be actively supported ${bold}at the end of 2016${normal}.
+Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -130,11 +135,11 @@ Node.js 0.10 will cease to be actively supported ${bold}at the end of 2016${norm
 }
 
 script_deprecation_warning() {
-    if [ "X" == "X" ]; then
+    if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
 "                            DEPRECATION WARNING                            " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install Node.js 0.10, is being deprecated and will eventually be made
+  install Node.js v0.10, is being deprecated and will eventually be made
   inactive.
 
   You should use the script that corresponds to the version of Node.js you
@@ -163,7 +168,7 @@ setup() {
 
 script_deprecation_warning
 
-print_status "Installing the NodeSource Node.js 0.10 repo..."
+print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
@@ -255,7 +260,7 @@ fi
 ## we include the arch in the directory tree anyway)
 RELEASE_URL_VERSION_STRING="${DIST_TYPE}${DIST_VERSION}"
 RELEASE_URL="\
-https://rpm.nodesource.com/pub_0.10/\
+https://rpm.nodesource.com/${NODEREPO}/\
 ${DIST_TYPE}/\
 ${DIST_VERSION}/\
 ${DIST_ARCH}/\
@@ -346,7 +351,7 @@ if [ "X${EXISTING_NODE}" != "X" ]; then
 
   print_status "\
 Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y nodejs npm\033[22m\` (as root) to remove these first.\
+Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
 "
 
 fi
@@ -354,7 +359,7 @@ fi
 node_deprecation_warning
 
 print_status "\
-Run \`\033[1myum install -y nodejs\033[22m\` (as root) to install Node.js 0.10 and npm.\n\
+Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
 You may also need development tools to build native addons:\n\
   \`yum install -y gcc-c++ make\`\
 "

--- a/rpm/setup
+++ b/rpm/setup
@@ -20,6 +20,41 @@ print_status() {
   echo
 }
 
+if test -t 1; then # if terminal
+    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        termcols=$(tput cols)
+        bold="$(tput bold)"
+        underline="$(tput smul)"
+        standout="$(tput smso)"
+        normal="$(tput sgr0)"
+        black="$(tput setaf 0)"
+        red="$(tput setaf 1)"
+        green="$(tput setaf 2)"
+        yellow="$(tput setaf 3)"
+        blue="$(tput setaf 4)"
+        magenta="$(tput setaf 5)"
+        cyan="$(tput setaf 6)"
+        white="$(tput setaf 7)"
+    fi
+fi
+
+print_bold() {
+    title="$1"
+    text="$2"
+
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+    echo
+    echo -e "  ${bold}${yellow}${title}${normal}"
+    echo
+    echo -en "  ${text}"
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+}
+
 bail() {
   echo 'Error executing command, exiting'
   exit 1
@@ -34,7 +69,99 @@ exec_cmd() {
   exec_cmd_nobail "$1" || bail
 }
 
+node_deprecation_warning() {
+    if [ "XNode.js 0.10" == "XNode.js v0.10" ]; then
+        print_bold \
+"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
+Node.js 0.10 will cease to be actively supported in ${bold}October 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 5 seconds ..."
+        echo
+        sleep 5
+    elif [ "XNode.js 0.10" == "XNode.js v0.12" ]; then
+        print_bold \
+"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
+Node.js 0.10 will cease to be actively supported ${bold}at the end of 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 3 seconds ..."
+        echo
+        sleep 3
+    fi
+}
+
+script_deprecation_warning() {
+    if [ "X" == "X" ]; then
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
+  install Node.js 0.10, is being deprecated and will eventually be made
+  inactive.
+
+  You should use the script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo
+        sleep 10
+    fi
+}
+
 setup() {
+
+script_deprecation_warning
 
 print_status "Installing the NodeSource Node.js 0.10 repo..."
 
@@ -223,6 +350,8 @@ Run \`\033[1myum remove -y nodejs npm\033[22m\` (as root) to remove these first.
 "
 
 fi
+
+node_deprecation_warning
 
 print_status "\
 Run \`\033[1myum install -y nodejs\033[22m\` (as root) to install Node.js 0.10 and npm.\n\

--- a/rpm/setup_0.10
+++ b/rpm/setup_0.10
@@ -20,6 +20,41 @@ print_status() {
   echo
 }
 
+if test -t 1; then # if terminal
+    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        termcols=$(tput cols)
+        bold="$(tput bold)"
+        underline="$(tput smul)"
+        standout="$(tput smso)"
+        normal="$(tput sgr0)"
+        black="$(tput setaf 0)"
+        red="$(tput setaf 1)"
+        green="$(tput setaf 2)"
+        yellow="$(tput setaf 3)"
+        blue="$(tput setaf 4)"
+        magenta="$(tput setaf 5)"
+        cyan="$(tput setaf 6)"
+        white="$(tput setaf 7)"
+    fi
+fi
+
+print_bold() {
+    title="$1"
+    text="$2"
+
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+    echo
+    echo -e "  ${bold}${yellow}${title}${normal}"
+    echo
+    echo -en "  ${text}"
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+}
+
 bail() {
   echo 'Error executing command, exiting'
   exit 1
@@ -34,7 +69,99 @@ exec_cmd() {
   exec_cmd_nobail "$1" || bail
 }
 
+node_deprecation_warning() {
+    if [ "XNode.js 0.10" == "XNode.js v0.10" ]; then
+        print_bold \
+"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
+Node.js 0.10 will cease to be actively supported in ${bold}October 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 5 seconds ..."
+        echo
+        sleep 5
+    elif [ "XNode.js 0.10" == "XNode.js v0.12" ]; then
+        print_bold \
+"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
+Node.js 0.10 will cease to be actively supported ${bold}at the end of 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 3 seconds ..."
+        echo
+        sleep 3
+    fi
+}
+
+script_deprecation_warning() {
+    if [ "X_0.10" == "X" ]; then
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
+  install Node.js 0.10, is being deprecated and will eventually be made
+  inactive.
+
+  You should use the script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo
+        sleep 10
+    fi
+}
+
 setup() {
+
+script_deprecation_warning
 
 print_status "Installing the NodeSource Node.js 0.10 repo..."
 
@@ -223,6 +350,8 @@ Run \`\033[1myum remove -y nodejs npm\033[22m\` (as root) to remove these first.
 "
 
 fi
+
+node_deprecation_warning
 
 print_status "\
 Run \`\033[1myum install -y nodejs\033[22m\` (as root) to install Node.js 0.10 and npm.\n\

--- a/rpm/setup_0.10
+++ b/rpm/setup_0.10
@@ -13,6 +13,11 @@
 # wget -qO- https://rpm.nodesource.com/setup_0.10 | bash -
 #
 
+SCRSUFFIX="_0.10"
+NODENAME="Node.js 0.10"
+NODEREPO="pub_0.10"
+NODEPKG="nodejs"
+
 print_status() {
   local outp=$(echo "$1" | sed -r 's/\\n/\\n## /mg')
   echo
@@ -70,10 +75,10 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "XNode.js 0.10" == "XNode.js v0.10" ]; then
+    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js 0.10 will cease to be actively supported in ${bold}October 2016${normal}.
+Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -98,10 +103,10 @@ Node.js 0.10 will cease to be actively supported in ${bold}October 2016${normal}
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
-    elif [ "XNode.js 0.10" == "XNode.js v0.12" ]; then
+    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js 0.10 will cease to be actively supported ${bold}at the end of 2016${normal}.
+Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -130,11 +135,11 @@ Node.js 0.10 will cease to be actively supported ${bold}at the end of 2016${norm
 }
 
 script_deprecation_warning() {
-    if [ "X_0.10" == "X" ]; then
+    if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
 "                            DEPRECATION WARNING                            " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install Node.js 0.10, is being deprecated and will eventually be made
+  install Node.js v0.10, is being deprecated and will eventually be made
   inactive.
 
   You should use the script that corresponds to the version of Node.js you
@@ -163,7 +168,7 @@ setup() {
 
 script_deprecation_warning
 
-print_status "Installing the NodeSource Node.js 0.10 repo..."
+print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
@@ -255,7 +260,7 @@ fi
 ## we include the arch in the directory tree anyway)
 RELEASE_URL_VERSION_STRING="${DIST_TYPE}${DIST_VERSION}"
 RELEASE_URL="\
-https://rpm.nodesource.com/pub_0.10/\
+https://rpm.nodesource.com/${NODEREPO}/\
 ${DIST_TYPE}/\
 ${DIST_VERSION}/\
 ${DIST_ARCH}/\
@@ -346,7 +351,7 @@ if [ "X${EXISTING_NODE}" != "X" ]; then
 
   print_status "\
 Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y nodejs npm\033[22m\` (as root) to remove these first.\
+Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
 "
 
 fi
@@ -354,7 +359,7 @@ fi
 node_deprecation_warning
 
 print_status "\
-Run \`\033[1myum install -y nodejs\033[22m\` (as root) to install Node.js 0.10 and npm.\n\
+Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
 You may also need development tools to build native addons:\n\
   \`yum install -y gcc-c++ make\`\
 "

--- a/rpm/setup_0.12
+++ b/rpm/setup_0.12
@@ -13,6 +13,11 @@
 # wget -qO- https://rpm.nodesource.com/setup_0.12 | bash -
 #
 
+SCRSUFFIX="_0.12"
+NODENAME="Node.js 0.12"
+NODEREPO="pub_0.12"
+NODEPKG="nodejs"
+
 print_status() {
   local outp=$(echo "$1" | sed -r 's/\\n/\\n## /mg')
   echo
@@ -70,10 +75,10 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "XNode.js 0.12" == "XNode.js v0.10" ]; then
+    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js 0.12 will cease to be actively supported in ${bold}October 2016${normal}.
+Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -98,10 +103,10 @@ Node.js 0.12 will cease to be actively supported in ${bold}October 2016${normal}
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
-    elif [ "XNode.js 0.12" == "XNode.js v0.12" ]; then
+    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js 0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
+Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -130,11 +135,11 @@ Node.js 0.12 will cease to be actively supported ${bold}at the end of 2016${norm
 }
 
 script_deprecation_warning() {
-    if [ "X_0.12" == "X" ]; then
+    if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
 "                            DEPRECATION WARNING                            " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install Node.js 0.12, is being deprecated and will eventually be made
+  install Node.js v0.10, is being deprecated and will eventually be made
   inactive.
 
   You should use the script that corresponds to the version of Node.js you
@@ -163,7 +168,7 @@ setup() {
 
 script_deprecation_warning
 
-print_status "Installing the NodeSource Node.js 0.12 repo..."
+print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
@@ -255,7 +260,7 @@ fi
 ## we include the arch in the directory tree anyway)
 RELEASE_URL_VERSION_STRING="${DIST_TYPE}${DIST_VERSION}"
 RELEASE_URL="\
-https://rpm.nodesource.com/pub_0.12/\
+https://rpm.nodesource.com/${NODEREPO}/\
 ${DIST_TYPE}/\
 ${DIST_VERSION}/\
 ${DIST_ARCH}/\
@@ -346,7 +351,7 @@ if [ "X${EXISTING_NODE}" != "X" ]; then
 
   print_status "\
 Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y nodejs npm\033[22m\` (as root) to remove these first.\
+Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
 "
 
 fi
@@ -354,7 +359,7 @@ fi
 node_deprecation_warning
 
 print_status "\
-Run \`\033[1myum install -y nodejs\033[22m\` (as root) to install Node.js 0.12 and npm.\n\
+Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
 You may also need development tools to build native addons:\n\
   \`yum install -y gcc-c++ make\`\
 "

--- a/rpm/setup_0.12
+++ b/rpm/setup_0.12
@@ -20,6 +20,41 @@ print_status() {
   echo
 }
 
+if test -t 1; then # if terminal
+    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        termcols=$(tput cols)
+        bold="$(tput bold)"
+        underline="$(tput smul)"
+        standout="$(tput smso)"
+        normal="$(tput sgr0)"
+        black="$(tput setaf 0)"
+        red="$(tput setaf 1)"
+        green="$(tput setaf 2)"
+        yellow="$(tput setaf 3)"
+        blue="$(tput setaf 4)"
+        magenta="$(tput setaf 5)"
+        cyan="$(tput setaf 6)"
+        white="$(tput setaf 7)"
+    fi
+fi
+
+print_bold() {
+    title="$1"
+    text="$2"
+
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+    echo
+    echo -e "  ${bold}${yellow}${title}${normal}"
+    echo
+    echo -en "  ${text}"
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+}
+
 bail() {
   echo 'Error executing command, exiting'
   exit 1
@@ -34,7 +69,99 @@ exec_cmd() {
   exec_cmd_nobail "$1" || bail
 }
 
+node_deprecation_warning() {
+    if [ "XNode.js 0.12" == "XNode.js v0.10" ]; then
+        print_bold \
+"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
+Node.js 0.12 will cease to be actively supported in ${bold}October 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 5 seconds ..."
+        echo
+        sleep 5
+    elif [ "XNode.js 0.12" == "XNode.js v0.12" ]; then
+        print_bold \
+"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
+Node.js 0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 3 seconds ..."
+        echo
+        sleep 3
+    fi
+}
+
+script_deprecation_warning() {
+    if [ "X_0.12" == "X" ]; then
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
+  install Node.js 0.12, is being deprecated and will eventually be made
+  inactive.
+
+  You should use the script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo
+        sleep 10
+    fi
+}
+
 setup() {
+
+script_deprecation_warning
 
 print_status "Installing the NodeSource Node.js 0.12 repo..."
 
@@ -223,6 +350,8 @@ Run \`\033[1myum remove -y nodejs npm\033[22m\` (as root) to remove these first.
 "
 
 fi
+
+node_deprecation_warning
 
 print_status "\
 Run \`\033[1myum install -y nodejs\033[22m\` (as root) to install Node.js 0.12 and npm.\n\

--- a/rpm/setup_4.x
+++ b/rpm/setup_4.x
@@ -13,6 +13,11 @@
 # wget -qO- https://rpm.nodesource.com/setup_4.x | bash -
 #
 
+SCRSUFFIX="_4.x"
+NODENAME="Node.js 4.x LTS Argon"
+NODEREPO="pub_4.x"
+NODEPKG="nodejs"
+
 print_status() {
   local outp=$(echo "$1" | sed -r 's/\\n/\\n## /mg')
   echo
@@ -70,10 +75,10 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "XNode.js 4.x LTS Argon" == "XNode.js v0.10" ]; then
+    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js 4.x LTS Argon will cease to be actively supported in ${bold}October 2016${normal}.
+Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -98,10 +103,10 @@ Node.js 4.x LTS Argon will cease to be actively supported in ${bold}October 2016
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
-    elif [ "XNode.js 4.x LTS Argon" == "XNode.js v0.12" ]; then
+    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js 4.x LTS Argon will cease to be actively supported ${bold}at the end of 2016${normal}.
+Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -130,11 +135,11 @@ Node.js 4.x LTS Argon will cease to be actively supported ${bold}at the end of 2
 }
 
 script_deprecation_warning() {
-    if [ "X_4.x" == "X" ]; then
+    if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
 "                            DEPRECATION WARNING                            " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install Node.js 4.x LTS Argon, is being deprecated and will eventually be made
+  install Node.js v0.10, is being deprecated and will eventually be made
   inactive.
 
   You should use the script that corresponds to the version of Node.js you
@@ -163,7 +168,7 @@ setup() {
 
 script_deprecation_warning
 
-print_status "Installing the NodeSource Node.js 4.x LTS Argon repo..."
+print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
@@ -255,7 +260,7 @@ fi
 ## we include the arch in the directory tree anyway)
 RELEASE_URL_VERSION_STRING="${DIST_TYPE}${DIST_VERSION}"
 RELEASE_URL="\
-https://rpm.nodesource.com/pub_4.x/\
+https://rpm.nodesource.com/${NODEREPO}/\
 ${DIST_TYPE}/\
 ${DIST_VERSION}/\
 ${DIST_ARCH}/\
@@ -346,7 +351,7 @@ if [ "X${EXISTING_NODE}" != "X" ]; then
 
   print_status "\
 Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y nodejs npm\033[22m\` (as root) to remove these first.\
+Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
 "
 
 fi
@@ -354,7 +359,7 @@ fi
 node_deprecation_warning
 
 print_status "\
-Run \`\033[1myum install -y nodejs\033[22m\` (as root) to install Node.js 4.x LTS Argon and npm.\n\
+Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
 You may also need development tools to build native addons:\n\
   \`yum install -y gcc-c++ make\`\
 "

--- a/rpm/setup_4.x
+++ b/rpm/setup_4.x
@@ -20,6 +20,41 @@ print_status() {
   echo
 }
 
+if test -t 1; then # if terminal
+    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        termcols=$(tput cols)
+        bold="$(tput bold)"
+        underline="$(tput smul)"
+        standout="$(tput smso)"
+        normal="$(tput sgr0)"
+        black="$(tput setaf 0)"
+        red="$(tput setaf 1)"
+        green="$(tput setaf 2)"
+        yellow="$(tput setaf 3)"
+        blue="$(tput setaf 4)"
+        magenta="$(tput setaf 5)"
+        cyan="$(tput setaf 6)"
+        white="$(tput setaf 7)"
+    fi
+fi
+
+print_bold() {
+    title="$1"
+    text="$2"
+
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+    echo
+    echo -e "  ${bold}${yellow}${title}${normal}"
+    echo
+    echo -en "  ${text}"
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+}
+
 bail() {
   echo 'Error executing command, exiting'
   exit 1
@@ -34,7 +69,99 @@ exec_cmd() {
   exec_cmd_nobail "$1" || bail
 }
 
+node_deprecation_warning() {
+    if [ "XNode.js 4.x LTS Argon" == "XNode.js v0.10" ]; then
+        print_bold \
+"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
+Node.js 4.x LTS Argon will cease to be actively supported in ${bold}October 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 5 seconds ..."
+        echo
+        sleep 5
+    elif [ "XNode.js 4.x LTS Argon" == "XNode.js v0.12" ]; then
+        print_bold \
+"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
+Node.js 4.x LTS Argon will cease to be actively supported ${bold}at the end of 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 3 seconds ..."
+        echo
+        sleep 3
+    fi
+}
+
+script_deprecation_warning() {
+    if [ "X_4.x" == "X" ]; then
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
+  install Node.js 4.x LTS Argon, is being deprecated and will eventually be made
+  inactive.
+
+  You should use the script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo
+        sleep 10
+    fi
+}
+
 setup() {
+
+script_deprecation_warning
 
 print_status "Installing the NodeSource Node.js 4.x LTS Argon repo..."
 
@@ -223,6 +350,8 @@ Run \`\033[1myum remove -y nodejs npm\033[22m\` (as root) to remove these first.
 "
 
 fi
+
+node_deprecation_warning
 
 print_status "\
 Run \`\033[1myum install -y nodejs\033[22m\` (as root) to install Node.js 4.x LTS Argon and npm.\n\

--- a/rpm/setup_5.x
+++ b/rpm/setup_5.x
@@ -13,6 +13,11 @@
 # wget -qO- https://rpm.nodesource.com/setup_5.x | bash -
 #
 
+SCRSUFFIX="_5.x"
+NODENAME="Node.js 5.x"
+NODEREPO="pub_5.x"
+NODEPKG="nodejs"
+
 print_status() {
   local outp=$(echo "$1" | sed -r 's/\\n/\\n## /mg')
   echo
@@ -70,10 +75,10 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "XNode.js 5.x" == "XNode.js v0.10" ]; then
+    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js 5.x will cease to be actively supported in ${bold}October 2016${normal}.
+Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -98,10 +103,10 @@ Node.js 5.x will cease to be actively supported in ${bold}October 2016${normal}.
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
-    elif [ "XNode.js 5.x" == "XNode.js v0.12" ]; then
+    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js 5.x will cease to be actively supported ${bold}at the end of 2016${normal}.
+Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -130,11 +135,11 @@ Node.js 5.x will cease to be actively supported ${bold}at the end of 2016${norma
 }
 
 script_deprecation_warning() {
-    if [ "X_5.x" == "X" ]; then
+    if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
 "                            DEPRECATION WARNING                            " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install Node.js 5.x, is being deprecated and will eventually be made
+  install Node.js v0.10, is being deprecated and will eventually be made
   inactive.
 
   You should use the script that corresponds to the version of Node.js you
@@ -163,7 +168,7 @@ setup() {
 
 script_deprecation_warning
 
-print_status "Installing the NodeSource Node.js 5.x repo..."
+print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
@@ -255,7 +260,7 @@ fi
 ## we include the arch in the directory tree anyway)
 RELEASE_URL_VERSION_STRING="${DIST_TYPE}${DIST_VERSION}"
 RELEASE_URL="\
-https://rpm.nodesource.com/pub_5.x/\
+https://rpm.nodesource.com/${NODEREPO}/\
 ${DIST_TYPE}/\
 ${DIST_VERSION}/\
 ${DIST_ARCH}/\
@@ -346,7 +351,7 @@ if [ "X${EXISTING_NODE}" != "X" ]; then
 
   print_status "\
 Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y nodejs npm\033[22m\` (as root) to remove these first.\
+Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
 "
 
 fi
@@ -354,7 +359,7 @@ fi
 node_deprecation_warning
 
 print_status "\
-Run \`\033[1myum install -y nodejs\033[22m\` (as root) to install Node.js 5.x and npm.\n\
+Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
 You may also need development tools to build native addons:\n\
   \`yum install -y gcc-c++ make\`\
 "

--- a/rpm/setup_5.x
+++ b/rpm/setup_5.x
@@ -20,6 +20,41 @@ print_status() {
   echo
 }
 
+if test -t 1; then # if terminal
+    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        termcols=$(tput cols)
+        bold="$(tput bold)"
+        underline="$(tput smul)"
+        standout="$(tput smso)"
+        normal="$(tput sgr0)"
+        black="$(tput setaf 0)"
+        red="$(tput setaf 1)"
+        green="$(tput setaf 2)"
+        yellow="$(tput setaf 3)"
+        blue="$(tput setaf 4)"
+        magenta="$(tput setaf 5)"
+        cyan="$(tput setaf 6)"
+        white="$(tput setaf 7)"
+    fi
+fi
+
+print_bold() {
+    title="$1"
+    text="$2"
+
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+    echo
+    echo -e "  ${bold}${yellow}${title}${normal}"
+    echo
+    echo -en "  ${text}"
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+}
+
 bail() {
   echo 'Error executing command, exiting'
   exit 1
@@ -34,7 +69,99 @@ exec_cmd() {
   exec_cmd_nobail "$1" || bail
 }
 
+node_deprecation_warning() {
+    if [ "XNode.js 5.x" == "XNode.js v0.10" ]; then
+        print_bold \
+"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
+Node.js 5.x will cease to be actively supported in ${bold}October 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 5 seconds ..."
+        echo
+        sleep 5
+    elif [ "XNode.js 5.x" == "XNode.js v0.12" ]; then
+        print_bold \
+"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
+Node.js 5.x will cease to be actively supported ${bold}at the end of 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 3 seconds ..."
+        echo
+        sleep 3
+    fi
+}
+
+script_deprecation_warning() {
+    if [ "X_5.x" == "X" ]; then
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
+  install Node.js 5.x, is being deprecated and will eventually be made
+  inactive.
+
+  You should use the script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo
+        sleep 10
+    fi
+}
+
 setup() {
+
+script_deprecation_warning
 
 print_status "Installing the NodeSource Node.js 5.x repo..."
 
@@ -223,6 +350,8 @@ Run \`\033[1myum remove -y nodejs npm\033[22m\` (as root) to remove these first.
 "
 
 fi
+
+node_deprecation_warning
 
 print_status "\
 Run \`\033[1myum install -y nodejs\033[22m\` (as root) to install Node.js 5.x and npm.\n\

--- a/rpm/setup_iojs_1.x
+++ b/rpm/setup_iojs_1.x
@@ -13,6 +13,11 @@
 # wget -qO- https://rpm.nodesource.com/setup_iojs_1.x | bash -
 #
 
+SCRSUFFIX="_iojs_1.x"
+NODENAME="io.js 1.x"
+NODEREPO="pub_iojs_1.x"
+NODEPKG="iojs"
+
 print_status() {
   local outp=$(echo "$1" | sed -r 's/\\n/\\n## /mg')
   echo
@@ -70,10 +75,10 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "Xio.js 1.x" == "XNode.js v0.10" ]; then
+    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-io.js 1.x will cease to be actively supported in ${bold}October 2016${normal}.
+Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -98,10 +103,10 @@ io.js 1.x will cease to be actively supported in ${bold}October 2016${normal}.
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
-    elif [ "Xio.js 1.x" == "XNode.js v0.12" ]; then
+    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-io.js 1.x will cease to be actively supported ${bold}at the end of 2016${normal}.
+Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -130,11 +135,11 @@ io.js 1.x will cease to be actively supported ${bold}at the end of 2016${normal}
 }
 
 script_deprecation_warning() {
-    if [ "X_iojs_1.x" == "X" ]; then
+    if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
 "                            DEPRECATION WARNING                            " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install io.js 1.x, is being deprecated and will eventually be made
+  install Node.js v0.10, is being deprecated and will eventually be made
   inactive.
 
   You should use the script that corresponds to the version of Node.js you
@@ -163,7 +168,7 @@ setup() {
 
 script_deprecation_warning
 
-print_status "Installing the NodeSource io.js 1.x repo..."
+print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
@@ -255,7 +260,7 @@ fi
 ## we include the arch in the directory tree anyway)
 RELEASE_URL_VERSION_STRING="${DIST_TYPE}${DIST_VERSION}"
 RELEASE_URL="\
-https://rpm.nodesource.com/pub_iojs_1.x/\
+https://rpm.nodesource.com/${NODEREPO}/\
 ${DIST_TYPE}/\
 ${DIST_VERSION}/\
 ${DIST_ARCH}/\
@@ -346,7 +351,7 @@ if [ "X${EXISTING_NODE}" != "X" ]; then
 
   print_status "\
 Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y iojs npm\033[22m\` (as root) to remove these first.\
+Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
 "
 
 fi
@@ -354,7 +359,7 @@ fi
 node_deprecation_warning
 
 print_status "\
-Run \`\033[1myum install -y iojs\033[22m\` (as root) to install io.js 1.x and npm.\n\
+Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
 You may also need development tools to build native addons:\n\
   \`yum install -y gcc-c++ make\`\
 "

--- a/rpm/setup_iojs_1.x
+++ b/rpm/setup_iojs_1.x
@@ -20,6 +20,41 @@ print_status() {
   echo
 }
 
+if test -t 1; then # if terminal
+    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        termcols=$(tput cols)
+        bold="$(tput bold)"
+        underline="$(tput smul)"
+        standout="$(tput smso)"
+        normal="$(tput sgr0)"
+        black="$(tput setaf 0)"
+        red="$(tput setaf 1)"
+        green="$(tput setaf 2)"
+        yellow="$(tput setaf 3)"
+        blue="$(tput setaf 4)"
+        magenta="$(tput setaf 5)"
+        cyan="$(tput setaf 6)"
+        white="$(tput setaf 7)"
+    fi
+fi
+
+print_bold() {
+    title="$1"
+    text="$2"
+
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+    echo
+    echo -e "  ${bold}${yellow}${title}${normal}"
+    echo
+    echo -en "  ${text}"
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+}
+
 bail() {
   echo 'Error executing command, exiting'
   exit 1
@@ -34,7 +69,99 @@ exec_cmd() {
   exec_cmd_nobail "$1" || bail
 }
 
+node_deprecation_warning() {
+    if [ "Xio.js 1.x" == "XNode.js v0.10" ]; then
+        print_bold \
+"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
+io.js 1.x will cease to be actively supported in ${bold}October 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 5 seconds ..."
+        echo
+        sleep 5
+    elif [ "Xio.js 1.x" == "XNode.js v0.12" ]; then
+        print_bold \
+"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
+io.js 1.x will cease to be actively supported ${bold}at the end of 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 3 seconds ..."
+        echo
+        sleep 3
+    fi
+}
+
+script_deprecation_warning() {
+    if [ "X_iojs_1.x" == "X" ]; then
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
+  install io.js 1.x, is being deprecated and will eventually be made
+  inactive.
+
+  You should use the script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo
+        sleep 10
+    fi
+}
+
 setup() {
+
+script_deprecation_warning
 
 print_status "Installing the NodeSource io.js 1.x repo..."
 
@@ -223,6 +350,8 @@ Run \`\033[1myum remove -y iojs npm\033[22m\` (as root) to remove these first.\
 "
 
 fi
+
+node_deprecation_warning
 
 print_status "\
 Run \`\033[1myum install -y iojs\033[22m\` (as root) to install io.js 1.x and npm.\n\

--- a/rpm/setup_iojs_2.x
+++ b/rpm/setup_iojs_2.x
@@ -13,6 +13,11 @@
 # wget -qO- https://rpm.nodesource.com/setup_iojs_2.x | bash -
 #
 
+SCRSUFFIX="_iojs_2.x"
+NODENAME="io.js 2.x"
+NODEREPO="pub_iojs_2.x"
+NODEPKG="iojs"
+
 print_status() {
   local outp=$(echo "$1" | sed -r 's/\\n/\\n## /mg')
   echo
@@ -70,10 +75,10 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "Xio.js 2.x" == "XNode.js v0.10" ]; then
+    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-io.js 2.x will cease to be actively supported in ${bold}October 2016${normal}.
+Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -98,10 +103,10 @@ io.js 2.x will cease to be actively supported in ${bold}October 2016${normal}.
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
-    elif [ "Xio.js 2.x" == "XNode.js v0.12" ]; then
+    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-io.js 2.x will cease to be actively supported ${bold}at the end of 2016${normal}.
+Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -130,11 +135,11 @@ io.js 2.x will cease to be actively supported ${bold}at the end of 2016${normal}
 }
 
 script_deprecation_warning() {
-    if [ "X_iojs_2.x" == "X" ]; then
+    if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
 "                            DEPRECATION WARNING                            " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install io.js 2.x, is being deprecated and will eventually be made
+  install Node.js v0.10, is being deprecated and will eventually be made
   inactive.
 
   You should use the script that corresponds to the version of Node.js you
@@ -163,7 +168,7 @@ setup() {
 
 script_deprecation_warning
 
-print_status "Installing the NodeSource io.js 2.x repo..."
+print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
@@ -255,7 +260,7 @@ fi
 ## we include the arch in the directory tree anyway)
 RELEASE_URL_VERSION_STRING="${DIST_TYPE}${DIST_VERSION}"
 RELEASE_URL="\
-https://rpm.nodesource.com/pub_iojs_2.x/\
+https://rpm.nodesource.com/${NODEREPO}/\
 ${DIST_TYPE}/\
 ${DIST_VERSION}/\
 ${DIST_ARCH}/\
@@ -346,7 +351,7 @@ if [ "X${EXISTING_NODE}" != "X" ]; then
 
   print_status "\
 Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y iojs npm\033[22m\` (as root) to remove these first.\
+Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
 "
 
 fi
@@ -354,7 +359,7 @@ fi
 node_deprecation_warning
 
 print_status "\
-Run \`\033[1myum install -y iojs\033[22m\` (as root) to install io.js 2.x and npm.\n\
+Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
 You may also need development tools to build native addons:\n\
   \`yum install -y gcc-c++ make\`\
 "

--- a/rpm/setup_iojs_2.x
+++ b/rpm/setup_iojs_2.x
@@ -20,6 +20,41 @@ print_status() {
   echo
 }
 
+if test -t 1; then # if terminal
+    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        termcols=$(tput cols)
+        bold="$(tput bold)"
+        underline="$(tput smul)"
+        standout="$(tput smso)"
+        normal="$(tput sgr0)"
+        black="$(tput setaf 0)"
+        red="$(tput setaf 1)"
+        green="$(tput setaf 2)"
+        yellow="$(tput setaf 3)"
+        blue="$(tput setaf 4)"
+        magenta="$(tput setaf 5)"
+        cyan="$(tput setaf 6)"
+        white="$(tput setaf 7)"
+    fi
+fi
+
+print_bold() {
+    title="$1"
+    text="$2"
+
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+    echo
+    echo -e "  ${bold}${yellow}${title}${normal}"
+    echo
+    echo -en "  ${text}"
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+}
+
 bail() {
   echo 'Error executing command, exiting'
   exit 1
@@ -34,7 +69,99 @@ exec_cmd() {
   exec_cmd_nobail "$1" || bail
 }
 
+node_deprecation_warning() {
+    if [ "Xio.js 2.x" == "XNode.js v0.10" ]; then
+        print_bold \
+"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
+io.js 2.x will cease to be actively supported in ${bold}October 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 5 seconds ..."
+        echo
+        sleep 5
+    elif [ "Xio.js 2.x" == "XNode.js v0.12" ]; then
+        print_bold \
+"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
+io.js 2.x will cease to be actively supported ${bold}at the end of 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 3 seconds ..."
+        echo
+        sleep 3
+    fi
+}
+
+script_deprecation_warning() {
+    if [ "X_iojs_2.x" == "X" ]; then
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
+  install io.js 2.x, is being deprecated and will eventually be made
+  inactive.
+
+  You should use the script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo
+        sleep 10
+    fi
+}
+
 setup() {
+
+script_deprecation_warning
 
 print_status "Installing the NodeSource io.js 2.x repo..."
 
@@ -223,6 +350,8 @@ Run \`\033[1myum remove -y iojs npm\033[22m\` (as root) to remove these first.\
 "
 
 fi
+
+node_deprecation_warning
 
 print_status "\
 Run \`\033[1myum install -y iojs\033[22m\` (as root) to install io.js 2.x and npm.\n\

--- a/rpm/src/_setup.sh
+++ b/rpm/src/_setup.sh
@@ -13,6 +13,11 @@
 # wget -qO- https://rpm.nodesource.com/setup{{suffix}} | bash -
 #
 
+SCRSUFFIX="{{suffix}}"
+NODENAME="{{name}}"
+NODEREPO="{{repo}}"
+NODEPKG="{{package}}"
+
 print_status() {
   local outp=$(echo "$1" | sed -r 's/\\n/\\n## /mg')
   echo
@@ -70,10 +75,10 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [ "X{{name}}" == "XNode.js v0.10" ]; then
+    if [ "X${NODENAME}" == "XNode.js v0.10" ]; then
         print_bold \
 "                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-{{name}} will cease to be actively supported in ${bold}October 2016${normal}.
+Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -98,10 +103,10 @@ node_deprecation_warning() {
         echo "Continuing in 5 seconds ..."
         echo
         sleep 5
-    elif [ "X{{name}}" == "XNode.js v0.12" ]; then
+    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
         print_bold \
 "                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-{{name}} will cease to be actively supported ${bold}at the end of 2016${normal}.
+Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
 
   This means you will not continue to receive security or critical stability
   updates for this version of Node.js beyond that time.
@@ -130,11 +135,11 @@ node_deprecation_warning() {
 }
 
 script_deprecation_warning() {
-    if [ "X{{suffix}}" == "X" ]; then
+    if [ "X${SCRSUFFIX}" == "X" ]; then
         print_bold \
 "                            DEPRECATION WARNING                            " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install {{name}}, is being deprecated and will eventually be made
+  install Node.js v0.10, is being deprecated and will eventually be made
   inactive.
 
   You should use the script that corresponds to the version of Node.js you
@@ -163,7 +168,7 @@ setup() {
 
 script_deprecation_warning
 
-print_status "Installing the NodeSource {{name}} repo..."
+print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
@@ -255,7 +260,7 @@ fi
 ## we include the arch in the directory tree anyway)
 RELEASE_URL_VERSION_STRING="${DIST_TYPE}${DIST_VERSION}"
 RELEASE_URL="\
-https://rpm.nodesource.com/{{repo}}/\
+https://rpm.nodesource.com/${NODEREPO}/\
 ${DIST_TYPE}/\
 ${DIST_VERSION}/\
 ${DIST_ARCH}/\
@@ -346,7 +351,7 @@ if [ "X${EXISTING_NODE}" != "X" ]; then
 
   print_status "\
 Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y {{package}} npm\033[22m\` (as root) to remove these first.\
+Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
 "
 
 fi
@@ -354,7 +359,7 @@ fi
 node_deprecation_warning
 
 print_status "\
-Run \`\033[1myum install -y {{package}}\033[22m\` (as root) to install {{name}} and npm.\n\
+Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
 You may also need development tools to build native addons:\n\
   \`yum install -y gcc-c++ make\`\
 "

--- a/rpm/src/_setup.sh
+++ b/rpm/src/_setup.sh
@@ -20,6 +20,41 @@ print_status() {
   echo
 }
 
+if test -t 1; then # if terminal
+    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        termcols=$(tput cols)
+        bold="$(tput bold)"
+        underline="$(tput smul)"
+        standout="$(tput smso)"
+        normal="$(tput sgr0)"
+        black="$(tput setaf 0)"
+        red="$(tput setaf 1)"
+        green="$(tput setaf 2)"
+        yellow="$(tput setaf 3)"
+        blue="$(tput setaf 4)"
+        magenta="$(tput setaf 5)"
+        cyan="$(tput setaf 6)"
+        white="$(tput setaf 7)"
+    fi
+fi
+
+print_bold() {
+    title="$1"
+    text="$2"
+
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+    echo
+    echo -e "  ${bold}${yellow}${title}${normal}"
+    echo
+    echo -en "  ${text}"
+    echo
+    echo "${red}================================================================================${normal}"
+    echo "${red}================================================================================${normal}"
+}
+
 bail() {
   echo 'Error executing command, exiting'
   exit 1
@@ -34,7 +69,99 @@ exec_cmd() {
   exec_cmd_nobail "$1" || bail
 }
 
+node_deprecation_warning() {
+    if [ "X{{name}}" == "XNode.js v0.10" ]; then
+        print_bold \
+"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
+{{name}} will cease to be actively supported in ${bold}October 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 5 seconds ..."
+        echo
+        sleep 5
+    elif [ "X{{name}}" == "XNode.js v0.12" ]; then
+        print_bold \
+"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
+{{name}} will cease to be actively supported ${bold}at the end of 2016${normal}.
+
+  This means you will not continue to receive security or critical stability
+  updates for this version of Node.js beyond that time.
+
+  You should begin migration to a newer version of Node.js as soon as
+  possible. Use the installation script that corresponds to the version of
+  Node.js you wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 3 seconds ..."
+        echo
+        sleep 3
+    fi
+}
+
+script_deprecation_warning() {
+    if [ "X{{suffix}}" == "X" ]; then
+        print_bold \
+"                            DEPRECATION WARNING                            " "\
+This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
+  install {{name}}, is being deprecated and will eventually be made
+  inactive.
+
+  You should use the script that corresponds to the version of Node.js you
+  wish to install. e.g.
+
+   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
+   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+
+  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
+  may be appropriate for you.
+
+  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
+  information about which versions of Node.js and which Linux distributions
+  are supported and how to use the install scripts.
+    ${bold}https://github.com/nodesource/distributions${normal}
+"
+
+        echo
+        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo
+        sleep 10
+    fi
+}
+
 setup() {
+
+script_deprecation_warning
 
 print_status "Installing the NodeSource {{name}} repo..."
 
@@ -223,6 +350,8 @@ Run \`\033[1myum remove -y {{package}} npm\033[22m\` (as root) to remove these f
 "
 
 fi
+
+node_deprecation_warning
 
 print_status "\
 Run \`\033[1myum install -y {{package}}\033[22m\` (as root) to install {{name}} and npm.\n\


### PR DESCRIPTION
See the changes in deb/src/_setup.sh and rpm/src/_setup.sh.

Print out warnings under certain conditions:

if you use a bare script, https://deb.nodesource.com/setup or https://rpm.nodesource.com/setup, we tell you that it's being deprecated and may soon be made inactive and that you should use a versioned script. This is done _at the begining of the script_ and you have to look at it for 10 seconds before it continues.

![screen shot 2016-06-18 at 4 59 42 pm](https://cloud.githubusercontent.com/assets/495647/16169564/d74dea02-3576-11e6-8d01-d5cd99a031c1.png)

If you use a v0.10 script it warns you of the Node deprecation in October and that you should upgrade. This is done at the _end_ of the script, just before the "run apt-get install nodejs" and "run yum install nodejs" bits, and waits for 5 seconds.

![screen shot 2016-06-18 at 5 00 06 pm](https://cloud.githubusercontent.com/assets/495647/16169568/e6b258de-3576-11e6-888d-620b9bbc3f84.png)

If you use a v0.12 script then it warns you of the Node deprecation at the end of the year and that you should upgrade. This is done at the _end_ of the script, just before the "run apt-get install nodejs" and "run yum install nodejs" bits, and waits for 3 seconds.

![screen shot 2016-06-18 at 5 00 16 pm](https://cloud.githubusercontent.com/assets/495647/16169569/f7ce67d4-3576-11e6-925f-813b9e4f2899.png)

Please review @retrohacker @chrislea @mweagle.