### PR TITLE
Remove references to distros that alias to Ubuntu Precise as it's EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ NodeSource will maintain support for stable, testing and unstable releases of De
 
 **Supported Linux Mint versions:**
 
-* **Linux Mint 13 "Maya"** (via Ubuntu 12.04 LTS)
 * **Linux Mint 17 "Qiana"** (via Ubuntu 14.04 LTS)
 * **Linux Mint 17.1 "Rebecca"** (via Ubuntu 14.04 LTS)
 * **Linux Mint 17.2 "Rafaela"** (via Ubuntu 14.04 LTS)
@@ -77,13 +76,11 @@ NodeSource will maintain support for stable, testing and unstable releases of De
 
 **Supported elementary OS versions:**
 
-* **elementary OS Luna** (via Ubuntu 12.04 LTS)
 * **elementary OS Freya** (via Ubuntu 14.04 LTS)
 * **elementary OS Loki** (via Ubuntu 16.04)
 
 **Supported Trisquel versions:**
 
-* **Trisquel 6 "Toutatis"** (via Ubuntu 12.04 LTS)
 * **Trisquel 7 "Belenos"** (via Ubuntu 14.04 LTS)
 
 **Supported BOSS versions:**


### PR DESCRIPTION
In relation to #494 and aa6fc261872a8a5633bc96602147083311141eed