### PR TITLE
Added support for PureOS v8 "green"

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ NodeSource will maintain support for stable, testing and unstable releases of De
 
 * **Hydrogen (rc2)** (via Debian 8)
 
+**Supported PureOS versions:**
+
+* **PureOS 8 "Green"** (via Debian 8)
+
 <a name="debinstall"></a>
 ### Installation instructions
 

--- a/deb/setup
+++ b/deb/setup
@@ -257,7 +257,6 @@ check_alt() {
 
 check_alt "Kali"          "sana"     "Debian" "jessie"
 check_alt "Kali"          "kali-rolling" "Debian" "jessie"
-check_alt "Debian"        "stretch"  "Debian" "jessie"
 check_alt "Linux Mint"    "maya"     "Ubuntu" "precise"
 check_alt "Linux Mint"    "qiana"    "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rafaela"  "Ubuntu" "trusty"
@@ -265,6 +264,7 @@ check_alt "Linux Mint"    "rebecca"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rosa"     "Ubuntu" "trusty"
 check_alt "Linux Mint"    "sarah"    "Ubuntu" "xenial"
 check_alt "Linux Mint"    "serena"   "Ubuntu" "xenial"
+check_alt "Linux Mint"    "sonya"    "Ubuntu" "xenial"
 check_alt "LMDE"          "betsy"    "Debian" "jessie"
 check_alt "elementaryOS"  "luna"     "Ubuntu" "precise"
 check_alt "elementaryOS"  "freya"    "Ubuntu" "trusty"
@@ -274,6 +274,7 @@ check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
 check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 check_alt "bunsenlabs"    "bunsen-hydrogen" "Debian" "jessie"
 check_alt "Tanglu"        "chromodoris" "Debian" "jessie"
+check_alt "PureOS"        "green"    "Debian" "jessie"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/setup_0.10
+++ b/deb/setup_0.10
@@ -257,7 +257,6 @@ check_alt() {
 
 check_alt "Kali"          "sana"     "Debian" "jessie"
 check_alt "Kali"          "kali-rolling" "Debian" "jessie"
-check_alt "Debian"        "stretch"  "Debian" "jessie"
 check_alt "Linux Mint"    "maya"     "Ubuntu" "precise"
 check_alt "Linux Mint"    "qiana"    "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rafaela"  "Ubuntu" "trusty"
@@ -265,6 +264,7 @@ check_alt "Linux Mint"    "rebecca"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rosa"     "Ubuntu" "trusty"
 check_alt "Linux Mint"    "sarah"    "Ubuntu" "xenial"
 check_alt "Linux Mint"    "serena"   "Ubuntu" "xenial"
+check_alt "Linux Mint"    "sonya"    "Ubuntu" "xenial"
 check_alt "LMDE"          "betsy"    "Debian" "jessie"
 check_alt "elementaryOS"  "luna"     "Ubuntu" "precise"
 check_alt "elementaryOS"  "freya"    "Ubuntu" "trusty"
@@ -274,6 +274,7 @@ check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
 check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 check_alt "bunsenlabs"    "bunsen-hydrogen" "Debian" "jessie"
 check_alt "Tanglu"        "chromodoris" "Debian" "jessie"
+check_alt "PureOS"        "green"    "Debian" "jessie"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/setup_0.12
+++ b/deb/setup_0.12
@@ -257,7 +257,6 @@ check_alt() {
 
 check_alt "Kali"          "sana"     "Debian" "jessie"
 check_alt "Kali"          "kali-rolling" "Debian" "jessie"
-check_alt "Debian"        "stretch"  "Debian" "jessie"
 check_alt "Linux Mint"    "maya"     "Ubuntu" "precise"
 check_alt "Linux Mint"    "qiana"    "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rafaela"  "Ubuntu" "trusty"
@@ -265,6 +264,7 @@ check_alt "Linux Mint"    "rebecca"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rosa"     "Ubuntu" "trusty"
 check_alt "Linux Mint"    "sarah"    "Ubuntu" "xenial"
 check_alt "Linux Mint"    "serena"   "Ubuntu" "xenial"
+check_alt "Linux Mint"    "sonya"    "Ubuntu" "xenial"
 check_alt "LMDE"          "betsy"    "Debian" "jessie"
 check_alt "elementaryOS"  "luna"     "Ubuntu" "precise"
 check_alt "elementaryOS"  "freya"    "Ubuntu" "trusty"
@@ -274,6 +274,7 @@ check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
 check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 check_alt "bunsenlabs"    "bunsen-hydrogen" "Debian" "jessie"
 check_alt "Tanglu"        "chromodoris" "Debian" "jessie"
+check_alt "PureOS"        "green"    "Debian" "jessie"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/setup_4.x
+++ b/deb/setup_4.x
@@ -274,6 +274,7 @@ check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
 check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 check_alt "bunsenlabs"    "bunsen-hydrogen" "Debian" "jessie"
 check_alt "Tanglu"        "chromodoris" "Debian" "jessie"
+check_alt "PureOS"        "green"    "Debian" "jessie"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/setup_5.x
+++ b/deb/setup_5.x
@@ -257,7 +257,6 @@ check_alt() {
 
 check_alt "Kali"          "sana"     "Debian" "jessie"
 check_alt "Kali"          "kali-rolling" "Debian" "jessie"
-check_alt "Debian"        "stretch"  "Debian" "jessie"
 check_alt "Linux Mint"    "maya"     "Ubuntu" "precise"
 check_alt "Linux Mint"    "qiana"    "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rafaela"  "Ubuntu" "trusty"
@@ -265,6 +264,7 @@ check_alt "Linux Mint"    "rebecca"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rosa"     "Ubuntu" "trusty"
 check_alt "Linux Mint"    "sarah"    "Ubuntu" "xenial"
 check_alt "Linux Mint"    "serena"   "Ubuntu" "xenial"
+check_alt "Linux Mint"    "sonya"    "Ubuntu" "xenial"
 check_alt "LMDE"          "betsy"    "Debian" "jessie"
 check_alt "elementaryOS"  "luna"     "Ubuntu" "precise"
 check_alt "elementaryOS"  "freya"    "Ubuntu" "trusty"
@@ -274,6 +274,7 @@ check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
 check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 check_alt "bunsenlabs"    "bunsen-hydrogen" "Debian" "jessie"
 check_alt "Tanglu"        "chromodoris" "Debian" "jessie"
+check_alt "PureOS"        "green"    "Debian" "jessie"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/setup_6.x
+++ b/deb/setup_6.x
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v6.x repo onto a
+# Script to install the NodeSource Node.js v6.x LTS Boron repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -15,7 +15,7 @@
 
 export DEBIAN_FRONTEND=noninteractive
 SCRSUFFIX="_6.x"
-NODENAME="Node.js v6.x"
+NODENAME="Node.js v6.x LTS Boron"
 NODEREPO="node_6.x"
 NODEPKG="nodejs"
 
@@ -274,6 +274,7 @@ check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
 check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 check_alt "bunsenlabs"    "bunsen-hydrogen" "Debian" "jessie"
 check_alt "Tanglu"        "chromodoris" "Debian" "jessie"
+check_alt "PureOS"        "green"    "Debian" "jessie"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/setup_7.x
+++ b/deb/setup_7.x
@@ -274,6 +274,7 @@ check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
 check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 check_alt "bunsenlabs"    "bunsen-hydrogen" "Debian" "jessie"
 check_alt "Tanglu"        "chromodoris" "Debian" "jessie"
+check_alt "PureOS"        "green"    "Debian" "jessie"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/setup_8.x
+++ b/deb/setup_8.x
@@ -274,6 +274,7 @@ check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
 check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 check_alt "bunsenlabs"    "bunsen-hydrogen" "Debian" "jessie"
 check_alt "Tanglu"        "chromodoris" "Debian" "jessie"
+check_alt "PureOS"        "green"    "Debian" "jessie"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/setup_dev
+++ b/deb/setup_dev
@@ -257,7 +257,6 @@ check_alt() {
 
 check_alt "Kali"          "sana"     "Debian" "jessie"
 check_alt "Kali"          "kali-rolling" "Debian" "jessie"
-check_alt "Debian"        "stretch"  "Debian" "jessie"
 check_alt "Linux Mint"    "maya"     "Ubuntu" "precise"
 check_alt "Linux Mint"    "qiana"    "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rafaela"  "Ubuntu" "trusty"
@@ -265,6 +264,7 @@ check_alt "Linux Mint"    "rebecca"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rosa"     "Ubuntu" "trusty"
 check_alt "Linux Mint"    "sarah"    "Ubuntu" "xenial"
 check_alt "Linux Mint"    "serena"   "Ubuntu" "xenial"
+check_alt "Linux Mint"    "sonya"    "Ubuntu" "xenial"
 check_alt "LMDE"          "betsy"    "Debian" "jessie"
 check_alt "elementaryOS"  "luna"     "Ubuntu" "precise"
 check_alt "elementaryOS"  "freya"    "Ubuntu" "trusty"
@@ -274,6 +274,7 @@ check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
 check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 check_alt "bunsenlabs"    "bunsen-hydrogen" "Debian" "jessie"
 check_alt "Tanglu"        "chromodoris" "Debian" "jessie"
+check_alt "PureOS"        "green"    "Debian" "jessie"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/setup_iojs_1.x
+++ b/deb/setup_iojs_1.x
@@ -257,7 +257,6 @@ check_alt() {
 
 check_alt "Kali"          "sana"     "Debian" "jessie"
 check_alt "Kali"          "kali-rolling" "Debian" "jessie"
-check_alt "Debian"        "stretch"  "Debian" "jessie"
 check_alt "Linux Mint"    "maya"     "Ubuntu" "precise"
 check_alt "Linux Mint"    "qiana"    "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rafaela"  "Ubuntu" "trusty"
@@ -265,6 +264,7 @@ check_alt "Linux Mint"    "rebecca"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rosa"     "Ubuntu" "trusty"
 check_alt "Linux Mint"    "sarah"    "Ubuntu" "xenial"
 check_alt "Linux Mint"    "serena"   "Ubuntu" "xenial"
+check_alt "Linux Mint"    "sonya"    "Ubuntu" "xenial"
 check_alt "LMDE"          "betsy"    "Debian" "jessie"
 check_alt "elementaryOS"  "luna"     "Ubuntu" "precise"
 check_alt "elementaryOS"  "freya"    "Ubuntu" "trusty"
@@ -274,6 +274,7 @@ check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
 check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 check_alt "bunsenlabs"    "bunsen-hydrogen" "Debian" "jessie"
 check_alt "Tanglu"        "chromodoris" "Debian" "jessie"
+check_alt "PureOS"        "green"    "Debian" "jessie"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/setup_iojs_2.x
+++ b/deb/setup_iojs_2.x
@@ -257,7 +257,6 @@ check_alt() {
 
 check_alt "Kali"          "sana"     "Debian" "jessie"
 check_alt "Kali"          "kali-rolling" "Debian" "jessie"
-check_alt "Debian"        "stretch"  "Debian" "jessie"
 check_alt "Linux Mint"    "maya"     "Ubuntu" "precise"
 check_alt "Linux Mint"    "qiana"    "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rafaela"  "Ubuntu" "trusty"
@@ -265,6 +264,7 @@ check_alt "Linux Mint"    "rebecca"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rosa"     "Ubuntu" "trusty"
 check_alt "Linux Mint"    "sarah"    "Ubuntu" "xenial"
 check_alt "Linux Mint"    "serena"   "Ubuntu" "xenial"
+check_alt "Linux Mint"    "sonya"    "Ubuntu" "xenial"
 check_alt "LMDE"          "betsy"    "Debian" "jessie"
 check_alt "elementaryOS"  "luna"     "Ubuntu" "precise"
 check_alt "elementaryOS"  "freya"    "Ubuntu" "trusty"
@@ -274,6 +274,7 @@ check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
 check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 check_alt "bunsenlabs"    "bunsen-hydrogen" "Debian" "jessie"
 check_alt "Tanglu"        "chromodoris" "Debian" "jessie"
+check_alt "PureOS"        "green"    "Debian" "jessie"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/setup_iojs_3.x
+++ b/deb/setup_iojs_3.x
@@ -257,7 +257,6 @@ check_alt() {
 
 check_alt "Kali"          "sana"     "Debian" "jessie"
 check_alt "Kali"          "kali-rolling" "Debian" "jessie"
-check_alt "Debian"        "stretch"  "Debian" "jessie"
 check_alt "Linux Mint"    "maya"     "Ubuntu" "precise"
 check_alt "Linux Mint"    "qiana"    "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rafaela"  "Ubuntu" "trusty"
@@ -265,6 +264,7 @@ check_alt "Linux Mint"    "rebecca"  "Ubuntu" "trusty"
 check_alt "Linux Mint"    "rosa"     "Ubuntu" "trusty"
 check_alt "Linux Mint"    "sarah"    "Ubuntu" "xenial"
 check_alt "Linux Mint"    "serena"   "Ubuntu" "xenial"
+check_alt "Linux Mint"    "sonya"    "Ubuntu" "xenial"
 check_alt "LMDE"          "betsy"    "Debian" "jessie"
 check_alt "elementaryOS"  "luna"     "Ubuntu" "precise"
 check_alt "elementaryOS"  "freya"    "Ubuntu" "trusty"
@@ -274,6 +274,7 @@ check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
 check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 check_alt "bunsenlabs"    "bunsen-hydrogen" "Debian" "jessie"
 check_alt "Tanglu"        "chromodoris" "Debian" "jessie"
+check_alt "PureOS"        "green"    "Debian" "jessie"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/src/_setup.sh
+++ b/deb/src/_setup.sh
@@ -274,6 +274,7 @@ check_alt "Trisquel"      "belenos"  "Ubuntu" "trusty"
 check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 check_alt "bunsenlabs"    "bunsen-hydrogen" "Debian" "jessie"
 check_alt "Tanglu"        "chromodoris" "Debian" "jessie"
+check_alt "PureOS"        "green"    "Debian" "jessie"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."


### PR DESCRIPTION
Recently decided to try PureOS, the official operating system used on Purism laptops. I added an alias for PureOS v8 (the current version) in ```deb/src/_setup.sh``` and then ran the ```deb/src/build.sh``` script. 

It looks like other contributors have been editing the individual setup scripts manually instead of using the build script, which is why there are some changes related to Linux Mint.

Let me know if anything needs to be changed! <3