### PR TITLE
Support for PureOS

### DIFF
--- a/deb/setup_8.x
+++ b/deb/setup_8.x
@@ -276,6 +276,7 @@ check_alt "Trisquel"      "flidas"   "Ubuntu" "xenial"
 check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 check_alt "bunsenlabs"    "bunsen-hydrogen" "Debian" "jessie"
 check_alt "Tanglu"        "chromodoris" "Debian" "jessie"
+check_alt "PureOS"        "green"    "Ubuntu" "xenial"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."

--- a/deb/setup_9.x
+++ b/deb/setup_9.x
@@ -276,6 +276,7 @@ check_alt "Trisquel"      "flidas"   "Ubuntu" "xenial"
 check_alt "BOSS"          "anokha"   "Debian" "wheezy"
 check_alt "bunsenlabs"    "bunsen-hydrogen" "Debian" "jessie"
 check_alt "Tanglu"        "chromodoris" "Debian" "jessie"
+check_alt "PureOS"        "green"    "Ubuntu" "xenial"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."


### PR DESCRIPTION
PureOS is "just" Ubuntu 16.04, but reports itself as "green."  I have text the 9.x script of this pull request and have requested that @aurovrata test 8.x

This is probably not an exhaustive pull request and leave it to nodesource-conversant contributors to tell me where else to copy these changes or else add them on top of this...