### PR TITLE
deprecate old, introduce 10, add Yarn instructions

### DIFF
--- a/deb/setup
+++ b/deb/setup
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v0.10 repo onto a
+# Script to install the NodeSource Node.js 0.10 repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -15,7 +15,7 @@
 
 export DEBIAN_FRONTEND=noninteractive
 SCRSUFFIX=""
-NODENAME="Node.js v0.10"
+NODENAME="Node.js 0.10"
 NODEREPO="node_0.10"
 NODEPKG="nodejs"
 
@@ -75,10 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -90,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -174,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js 0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -193,20 +135,21 @@ This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 if $(uname -m | grep -Eq ^armv6); then
-    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js v4 and later."
+    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js 4 and later."
     exit 1
 fi
 
@@ -336,9 +279,14 @@ print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-node_deprecation_warning
-
-print_status "Run \`apt-get install ${NODEPKG}\` (as root) to install ${NODENAME} and npm"
+print_status """Run \`${bold}sudo apt-get install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm
+## You may also need development tools to build native addons:
+     sudo apt-get install gcc g++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+     echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | sudo tee /etc/apt/sources.list.d/yarn.list
+     sudo apt-get update && sudo apt-get install yarn
+"""
 
 }
 

--- a/deb/setup_0.10
+++ b/deb/setup_0.10
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v0.10 repo onto a
+# Script to install the NodeSource Node.js 0.10 repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -15,7 +15,7 @@
 
 export DEBIAN_FRONTEND=noninteractive
 SCRSUFFIX="_0.10"
-NODENAME="Node.js v0.10"
+NODENAME="Node.js 0.10"
 NODEREPO="node_0.10"
 NODEPKG="nodejs"
 
@@ -75,10 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -90,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -174,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js 0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -193,20 +135,21 @@ This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 if $(uname -m | grep -Eq ^armv6); then
-    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js v4 and later."
+    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js 4 and later."
     exit 1
 fi
 
@@ -336,9 +279,14 @@ print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-node_deprecation_warning
-
-print_status "Run \`apt-get install ${NODEPKG}\` (as root) to install ${NODENAME} and npm"
+print_status """Run \`${bold}sudo apt-get install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm
+## You may also need development tools to build native addons:
+     sudo apt-get install gcc g++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+     echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | sudo tee /etc/apt/sources.list.d/yarn.list
+     sudo apt-get update && sudo apt-get install yarn
+"""
 
 }
 

--- a/deb/setup_0.12
+++ b/deb/setup_0.12
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v0.12 repo onto a
+# Script to install the NodeSource Node.js 0.12 repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -15,7 +15,7 @@
 
 export DEBIAN_FRONTEND=noninteractive
 SCRSUFFIX="_0.12"
-NODENAME="Node.js v0.12"
+NODENAME="Node.js 0.12"
 NODEREPO="node_0.12"
 NODEPKG="nodejs"
 
@@ -75,10 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -90,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -174,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js 0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -193,20 +135,21 @@ This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 if $(uname -m | grep -Eq ^armv6); then
-    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js v4 and later."
+    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js 4 and later."
     exit 1
 fi
 
@@ -336,9 +279,14 @@ print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-node_deprecation_warning
-
-print_status "Run \`apt-get install ${NODEPKG}\` (as root) to install ${NODENAME} and npm"
+print_status """Run \`${bold}sudo apt-get install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm
+## You may also need development tools to build native addons:
+     sudo apt-get install gcc g++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+     echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | sudo tee /etc/apt/sources.list.d/yarn.list
+     sudo apt-get update && sudo apt-get install yarn
+"""
 
 }
 

--- a/deb/setup_10.x
+++ b/deb/setup_10.x
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v10.x Dubnium repo onto a
+# Script to install the NodeSource Node.js 10.x repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -15,7 +15,7 @@
 
 export DEBIAN_FRONTEND=noninteractive
 SCRSUFFIX="_10.x"
-NODENAME="Node.js v10.x Dubnium"
+NODENAME="Node.js 10.x"
 NODEREPO="node_10.x"
 NODEPKG="nodejs"
 
@@ -75,10 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -90,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -174,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js 0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -193,20 +135,21 @@ This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 if $(uname -m | grep -Eq ^armv6); then
-    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js v4 and later."
+    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js 4 and later."
     exit 1
 fi
 
@@ -336,9 +279,14 @@ print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-node_deprecation_warning
-
-print_status "Run \`apt-get install ${NODEPKG}\` (as root) to install ${NODENAME} and npm"
+print_status """Run \`${bold}sudo apt-get install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm
+## You may also need development tools to build native addons:
+     sudo apt-get install gcc g++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+     echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | sudo tee /etc/apt/sources.list.d/yarn.list
+     sudo apt-get update && sudo apt-get install yarn
+"""
 
 }
 

--- a/deb/setup_4.x
+++ b/deb/setup_4.x
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v4.x LTS Argon repo onto a
+# Script to install the NodeSource Node.js 4.x LTS Argon repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -15,7 +15,7 @@
 
 export DEBIAN_FRONTEND=noninteractive
 SCRSUFFIX="_4.x"
-NODENAME="Node.js v4.x LTS Argon"
+NODENAME="Node.js 4.x LTS Argon"
 NODEREPO="node_4.x"
 NODEPKG="nodejs"
 
@@ -75,10 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -90,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -174,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js 0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -193,20 +135,21 @@ This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 if $(uname -m | grep -Eq ^armv6); then
-    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js v4 and later."
+    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js 4 and later."
     exit 1
 fi
 
@@ -336,9 +279,14 @@ print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-node_deprecation_warning
-
-print_status "Run \`apt-get install ${NODEPKG}\` (as root) to install ${NODENAME} and npm"
+print_status """Run \`${bold}sudo apt-get install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm
+## You may also need development tools to build native addons:
+     sudo apt-get install gcc g++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+     echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | sudo tee /etc/apt/sources.list.d/yarn.list
+     sudo apt-get update && sudo apt-get install yarn
+"""
 
 }
 

--- a/deb/setup_5.x
+++ b/deb/setup_5.x
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v5.x repo onto a
+# Script to install the NodeSource Node.js 5.x repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -15,7 +15,7 @@
 
 export DEBIAN_FRONTEND=noninteractive
 SCRSUFFIX="_5.x"
-NODENAME="Node.js v5.x"
+NODENAME="Node.js 5.x"
 NODEREPO="node_5.x"
 NODEPKG="nodejs"
 
@@ -75,10 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -90,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -174,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js 0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -193,20 +135,21 @@ This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 if $(uname -m | grep -Eq ^armv6); then
-    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js v4 and later."
+    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js 4 and later."
     exit 1
 fi
 
@@ -336,9 +279,14 @@ print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-node_deprecation_warning
-
-print_status "Run \`apt-get install ${NODEPKG}\` (as root) to install ${NODENAME} and npm"
+print_status """Run \`${bold}sudo apt-get install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm
+## You may also need development tools to build native addons:
+     sudo apt-get install gcc g++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+     echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | sudo tee /etc/apt/sources.list.d/yarn.list
+     sudo apt-get update && sudo apt-get install yarn
+"""
 
 }
 

--- a/deb/setup_6.x
+++ b/deb/setup_6.x
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v6.x LTS Boron repo onto a
+# Script to install the NodeSource Node.js 6.x LTS Boron repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -15,7 +15,7 @@
 
 export DEBIAN_FRONTEND=noninteractive
 SCRSUFFIX="_6.x"
-NODENAME="Node.js v6.x LTS Boron"
+NODENAME="Node.js 6.x LTS Boron"
 NODEREPO="node_6.x"
 NODEPKG="nodejs"
 
@@ -75,10 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -90,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -174,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js 0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -193,20 +135,21 @@ This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 if $(uname -m | grep -Eq ^armv6); then
-    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js v4 and later."
+    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js 4 and later."
     exit 1
 fi
 
@@ -336,9 +279,14 @@ print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-node_deprecation_warning
-
-print_status "Run \`apt-get install ${NODEPKG}\` (as root) to install ${NODENAME} and npm"
+print_status """Run \`${bold}sudo apt-get install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm
+## You may also need development tools to build native addons:
+     sudo apt-get install gcc g++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+     echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | sudo tee /etc/apt/sources.list.d/yarn.list
+     sudo apt-get update && sudo apt-get install yarn
+"""
 
 }
 

--- a/deb/setup_7.x
+++ b/deb/setup_7.x
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v7.x repo onto a
+# Script to install the NodeSource Node.js 7.x repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -15,7 +15,7 @@
 
 export DEBIAN_FRONTEND=noninteractive
 SCRSUFFIX="_7.x"
-NODENAME="Node.js v7.x"
+NODENAME="Node.js 7.x"
 NODEREPO="node_7.x"
 NODEPKG="nodejs"
 
@@ -75,10 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -90,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -174,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js 0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -193,20 +135,21 @@ This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 if $(uname -m | grep -Eq ^armv6); then
-    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js v4 and later."
+    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js 4 and later."
     exit 1
 fi
 
@@ -336,9 +279,14 @@ print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-node_deprecation_warning
-
-print_status "Run \`apt-get install ${NODEPKG}\` (as root) to install ${NODENAME} and npm"
+print_status """Run \`${bold}sudo apt-get install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm
+## You may also need development tools to build native addons:
+     sudo apt-get install gcc g++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+     echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | sudo tee /etc/apt/sources.list.d/yarn.list
+     sudo apt-get update && sudo apt-get install yarn
+"""
 
 }
 

--- a/deb/setup_8.x
+++ b/deb/setup_8.x
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v8.x LTS Carbon repo onto a
+# Script to install the NodeSource Node.js 8.x LTS Carbon repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -15,7 +15,7 @@
 
 export DEBIAN_FRONTEND=noninteractive
 SCRSUFFIX="_8.x"
-NODENAME="Node.js v8.x LTS Carbon"
+NODENAME="Node.js 8.x LTS Carbon"
 NODEREPO="node_8.x"
 NODEPKG="nodejs"
 
@@ -75,10 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -90,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -174,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js 0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -193,20 +135,21 @@ This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 if $(uname -m | grep -Eq ^armv6); then
-    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js v4 and later."
+    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js 4 and later."
     exit 1
 fi
 
@@ -336,9 +279,14 @@ print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-node_deprecation_warning
-
-print_status "Run \`apt-get install ${NODEPKG}\` (as root) to install ${NODENAME} and npm"
+print_status """Run \`${bold}sudo apt-get install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm
+## You may also need development tools to build native addons:
+     sudo apt-get install gcc g++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+     echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | sudo tee /etc/apt/sources.list.d/yarn.list
+     sudo apt-get update && sudo apt-get install yarn
+"""
 
 }
 

--- a/deb/setup_9.x
+++ b/deb/setup_9.x
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v9.x repo onto a
+# Script to install the NodeSource Node.js 9.x repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -15,7 +15,7 @@
 
 export DEBIAN_FRONTEND=noninteractive
 SCRSUFFIX="_9.x"
-NODENAME="Node.js v9.x"
+NODENAME="Node.js 9.x"
 NODEREPO="node_9.x"
 NODEPKG="nodejs"
 
@@ -75,10 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -90,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -174,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js 0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -193,20 +135,21 @@ This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 if $(uname -m | grep -Eq ^armv6); then
-    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js v4 and later."
+    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js 4 and later."
     exit 1
 fi
 
@@ -336,9 +279,14 @@ print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-node_deprecation_warning
-
-print_status "Run \`apt-get install ${NODEPKG}\` (as root) to install ${NODENAME} and npm"
+print_status """Run \`${bold}sudo apt-get install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm
+## You may also need development tools to build native addons:
+     sudo apt-get install gcc g++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+     echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | sudo tee /etc/apt/sources.list.d/yarn.list
+     sudo apt-get update && sudo apt-get install yarn
+"""
 
 }
 

--- a/deb/setup_dev
+++ b/deb/setup_dev
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v0.12 repo onto a
+# Script to install the NodeSource Node.js 0.12 repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -15,7 +15,7 @@
 
 export DEBIAN_FRONTEND=noninteractive
 SCRSUFFIX="_dev"
-NODENAME="Node.js v0.12"
+NODENAME="Node.js 0.12"
 NODEREPO="node_0.12"
 NODEPKG="nodejs"
 
@@ -75,10 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -90,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -174,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js 0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -193,20 +135,21 @@ This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 if $(uname -m | grep -Eq ^armv6); then
-    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js v4 and later."
+    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js 4 and later."
     exit 1
 fi
 
@@ -336,9 +279,14 @@ print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-node_deprecation_warning
-
-print_status "Run \`apt-get install ${NODEPKG}\` (as root) to install ${NODENAME} and npm"
+print_status """Run \`${bold}sudo apt-get install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm
+## You may also need development tools to build native addons:
+     sudo apt-get install gcc g++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+     echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | sudo tee /etc/apt/sources.list.d/yarn.list
+     sudo apt-get update && sudo apt-get install yarn
+"""
 
 }
 

--- a/deb/setup_iojs_1.x
+++ b/deb/setup_iojs_1.x
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource io.js v1.x repo onto a
+# Script to install the NodeSource io.js 1.x repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -15,7 +15,7 @@
 
 export DEBIAN_FRONTEND=noninteractive
 SCRSUFFIX="_iojs_1.x"
-NODENAME="io.js v1.x"
+NODENAME="io.js 1.x"
 NODEREPO="iojs_1.x"
 NODEPKG="iojs"
 
@@ -75,10 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -90,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -174,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js 0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -193,20 +135,21 @@ This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 if $(uname -m | grep -Eq ^armv6); then
-    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js v4 and later."
+    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js 4 and later."
     exit 1
 fi
 
@@ -336,9 +279,14 @@ print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-node_deprecation_warning
-
-print_status "Run \`apt-get install ${NODEPKG}\` (as root) to install ${NODENAME} and npm"
+print_status """Run \`${bold}sudo apt-get install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm
+## You may also need development tools to build native addons:
+     sudo apt-get install gcc g++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+     echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | sudo tee /etc/apt/sources.list.d/yarn.list
+     sudo apt-get update && sudo apt-get install yarn
+"""
 
 }
 

--- a/deb/setup_iojs_2.x
+++ b/deb/setup_iojs_2.x
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource io.js v2.x repo onto a
+# Script to install the NodeSource io.js 2.x repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -15,7 +15,7 @@
 
 export DEBIAN_FRONTEND=noninteractive
 SCRSUFFIX="_iojs_2.x"
-NODENAME="io.js v2.x"
+NODENAME="io.js 2.x"
 NODEREPO="iojs_2.x"
 NODEPKG="iojs"
 
@@ -75,10 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -90,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -174,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js 0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -193,20 +135,21 @@ This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 if $(uname -m | grep -Eq ^armv6); then
-    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js v4 and later."
+    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js 4 and later."
     exit 1
 fi
 
@@ -336,9 +279,14 @@ print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-node_deprecation_warning
-
-print_status "Run \`apt-get install ${NODEPKG}\` (as root) to install ${NODENAME} and npm"
+print_status """Run \`${bold}sudo apt-get install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm
+## You may also need development tools to build native addons:
+     sudo apt-get install gcc g++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+     echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | sudo tee /etc/apt/sources.list.d/yarn.list
+     sudo apt-get update && sudo apt-get install yarn
+"""
 
 }
 

--- a/deb/setup_iojs_3.x
+++ b/deb/setup_iojs_3.x
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource io.js v3.x repo onto a
+# Script to install the NodeSource io.js 3.x repo onto a
 # Debian or Ubuntu system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -15,7 +15,7 @@
 
 export DEBIAN_FRONTEND=noninteractive
 SCRSUFFIX="_iojs_3.x"
-NODENAME="io.js v3.x"
+NODENAME="io.js 3.x"
 NODEREPO="iojs_3.x"
 NODEPKG="iojs"
 
@@ -75,10 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -90,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -174,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js 0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -193,20 +135,21 @@ This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 if $(uname -m | grep -Eq ^armv6); then
-    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js v4 and later."
+    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js 4 and later."
     exit 1
 fi
 
@@ -336,9 +279,14 @@ print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-node_deprecation_warning
-
-print_status "Run \`apt-get install ${NODEPKG}\` (as root) to install ${NODENAME} and npm"
+print_status """Run \`${bold}sudo apt-get install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm
+## You may also need development tools to build native addons:
+     sudo apt-get install gcc g++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+     echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | sudo tee /etc/apt/sources.list.d/yarn.list
+     sudo apt-get update && sudo apt-get install yarn
+"""
 
 }
 

--- a/deb/src/_setup.sh
+++ b/deb/src/_setup.sh
@@ -75,10 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -90,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -174,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js 0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://deb.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://deb.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js 8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js 10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -193,20 +135,21 @@ This script, located at ${bold}https://deb.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 if $(uname -m | grep -Eq ^armv6); then
-    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js v4 and later."
+    print_status "You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js 4 and later."
     exit 1
 fi
 
@@ -336,9 +279,14 @@ print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-node_deprecation_warning
-
-print_status "Run \`apt-get install ${NODEPKG}\` (as root) to install ${NODENAME} and npm"
+print_status """Run \`${bold}sudo apt-get install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm
+## You may also need development tools to build native addons:
+     sudo apt-get install gcc g++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+     echo \"deb https://dl.yarnpkg.com/debian/ stable main\" | sudo tee /etc/apt/sources.list.d/yarn.list
+     sudo apt-get update && sudo apt-get install yarn
+"""
 
 }
 

--- a/deb/src/build.sh
+++ b/deb/src/build.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 
-RELEASES=( "node_0.10::nodejs:Node.js v0.10"
-           "node_0.10:_0.10:nodejs:Node.js v0.10"
-           "node_0.12:_0.12:nodejs:Node.js v0.12"
-           "node_0.12:_dev:nodejs:Node.js v0.12"
-           "iojs_1.x:_iojs_1.x:iojs:io.js v1.x"
-           "iojs_2.x:_iojs_2.x:iojs:io.js v2.x"
-           "iojs_3.x:_iojs_3.x:iojs:io.js v3.x"
-           "node_4.x:_4.x:nodejs:Node.js v4.x LTS Argon"
-           "node_5.x:_5.x:nodejs:Node.js v5.x"
-           "node_6.x:_6.x:nodejs:Node.js v6.x LTS Boron"
-           "node_7.x:_7.x:nodejs:Node.js v7.x"
-           "node_8.x:_8.x:nodejs:Node.js v8.x LTS Carbon"
-           "node_9.x:_9.x:nodejs:Node.js v9.x"
-           "node_10.x:_10.x:nodejs:Node.js v10.x Dubnium"
+RELEASES=( "node_0.10::nodejs:Node.js 0.10"
+           "node_0.10:_0.10:nodejs:Node.js 0.10"
+           "node_0.12:_0.12:nodejs:Node.js 0.12"
+           "node_0.12:_dev:nodejs:Node.js 0.12"
+           "iojs_1.x:_iojs_1.x:iojs:io.js 1.x"
+           "iojs_2.x:_iojs_2.x:iojs:io.js 2.x"
+           "iojs_3.x:_iojs_3.x:iojs:io.js 3.x"
+           "node_4.x:_4.x:nodejs:Node.js 4.x LTS Argon"
+           "node_5.x:_5.x:nodejs:Node.js 5.x"
+           "node_6.x:_6.x:nodejs:Node.js 6.x LTS Boron"
+           "node_7.x:_7.x:nodejs:Node.js 7.x"
+           "node_8.x:_8.x:nodejs:Node.js 8.x LTS Carbon"
+           "node_9.x:_9.x:nodejs:Node.js 9.x"
+           "node_10.x:_10.x:nodejs:Node.js 10.x"
          )
 SOURCE=_setup.sh
 DEST=../setup

--- a/rpm/setup
+++ b/rpm/setup
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v0.10 repo onto an
+# Script to install the NodeSource Node.js 0.10 repo onto an
 # Enterprise Linux or Fedora Core based system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -14,7 +14,7 @@
 #
 
 SCRSUFFIX=""
-NODENAME="Node.js v0.10"
+NODENAME="Node.js 0.10"
 NODEREPO="pub_0.10"
 NODEPKG="nodejs"
 
@@ -75,11 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-echo "X${NODENAME} == XNode.js v5.x"
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -91,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -175,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js v0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -194,28 +135,27 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
 if [ ! -x /bin/rpm ]; then
-  print_status "\
-You don't appear to be running an Enterprise Linux based \
-system, please contact NodeSource at \
-https://github.com/nodesource/distributions/issues if you think this \
-is incorrect or would like your distribution to be considered for \
-support.\
-"
+  print_status """You don't appear to be running an Enterprise Linux based system,
+please contact NodeSource at https://github.com/nodesource/distributions/issues
+if you think this is incorrect or would like your distribution to be considered
+for support.
+"""
   exit 1
 fi
 
@@ -342,15 +282,14 @@ if [ "$DIST_TYPE" == "el" ] && [ "$DIST_VERSION" == "5" ]; then
       exit 1
     fi
 
-    print_status "\
-The EPEL (Extra Packages for Enterprise Linux) repository is a\n\
-prerequisite for installing Node.js on your operating system. Please\n\
-add it and re-run this setup script.\n\
-\n\
-The EPEL repository RPM is available at:\n\
-  ${epel_url}${epel}\n\
-You can try installing with: \`rpm -ivh <url>\`\
-"
+    print_status """The EPEL (Extra Packages for Enterprise Linux) repository is a
+prerequisite for installing Node.js on your operating system. Please
+add it and re-run this setup script.
+
+The EPEL repository RPM is available at:
+  ${epel_url}${epel}
+You can try installing with: \`rpm -ivh <url>\`
+"""
 
     exit 1
   fi
@@ -385,22 +324,19 @@ EXISTING_NODE=$(rpm -qa 'node|npm|iojs' | grep -v nodesource)
 
 if [ "X${EXISTING_NODE}" != "X" ]; then
 
-  print_status "\
-Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
-"
+  print_status """Your system appears to already have Node.js installed from an alternative source.
+Run \`${bold}sudo yum remove -y ${NODEPKG} npm${normal}\` to remove these first.
+"""
 
 fi
 
-node_deprecation_warning
-
-print_status "\
-Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
-You may also need development tools to build native addons:\n\
-  \`yum install -y gcc-c++ make\`\
-"
-
-## Alternative to install dev tools: `yum groupinstall 'Development Tools'
+print_status """Run \`${bold}sudo yum install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm.
+## You may also need development tools to build native addons:
+     sudo yum install gcc-c++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | sudo tee /etc/yum.repos.d/yarn.repo
+     sudo yum install yarn
+"""
 
 exit 0
 

--- a/rpm/setup_0.10
+++ b/rpm/setup_0.10
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v0.10 repo onto an
+# Script to install the NodeSource Node.js 0.10 repo onto an
 # Enterprise Linux or Fedora Core based system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -14,7 +14,7 @@
 #
 
 SCRSUFFIX="_0.10"
-NODENAME="Node.js v0.10"
+NODENAME="Node.js 0.10"
 NODEREPO="pub_0.10"
 NODEPKG="nodejs"
 
@@ -75,11 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-echo "X${NODENAME} == XNode.js v5.x"
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -91,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -175,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js v0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -194,28 +135,27 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
 if [ ! -x /bin/rpm ]; then
-  print_status "\
-You don't appear to be running an Enterprise Linux based \
-system, please contact NodeSource at \
-https://github.com/nodesource/distributions/issues if you think this \
-is incorrect or would like your distribution to be considered for \
-support.\
-"
+  print_status """You don't appear to be running an Enterprise Linux based system,
+please contact NodeSource at https://github.com/nodesource/distributions/issues
+if you think this is incorrect or would like your distribution to be considered
+for support.
+"""
   exit 1
 fi
 
@@ -342,15 +282,14 @@ if [ "$DIST_TYPE" == "el" ] && [ "$DIST_VERSION" == "5" ]; then
       exit 1
     fi
 
-    print_status "\
-The EPEL (Extra Packages for Enterprise Linux) repository is a\n\
-prerequisite for installing Node.js on your operating system. Please\n\
-add it and re-run this setup script.\n\
-\n\
-The EPEL repository RPM is available at:\n\
-  ${epel_url}${epel}\n\
-You can try installing with: \`rpm -ivh <url>\`\
-"
+    print_status """The EPEL (Extra Packages for Enterprise Linux) repository is a
+prerequisite for installing Node.js on your operating system. Please
+add it and re-run this setup script.
+
+The EPEL repository RPM is available at:
+  ${epel_url}${epel}
+You can try installing with: \`rpm -ivh <url>\`
+"""
 
     exit 1
   fi
@@ -385,22 +324,19 @@ EXISTING_NODE=$(rpm -qa 'node|npm|iojs' | grep -v nodesource)
 
 if [ "X${EXISTING_NODE}" != "X" ]; then
 
-  print_status "\
-Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
-"
+  print_status """Your system appears to already have Node.js installed from an alternative source.
+Run \`${bold}sudo yum remove -y ${NODEPKG} npm${normal}\` to remove these first.
+"""
 
 fi
 
-node_deprecation_warning
-
-print_status "\
-Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
-You may also need development tools to build native addons:\n\
-  \`yum install -y gcc-c++ make\`\
-"
-
-## Alternative to install dev tools: `yum groupinstall 'Development Tools'
+print_status """Run \`${bold}sudo yum install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm.
+## You may also need development tools to build native addons:
+     sudo yum install gcc-c++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | sudo tee /etc/yum.repos.d/yarn.repo
+     sudo yum install yarn
+"""
 
 exit 0
 

--- a/rpm/setup_0.12
+++ b/rpm/setup_0.12
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v0.12 repo onto an
+# Script to install the NodeSource Node.js 0.12 repo onto an
 # Enterprise Linux or Fedora Core based system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -14,7 +14,7 @@
 #
 
 SCRSUFFIX="_0.12"
-NODENAME="Node.js v0.12"
+NODENAME="Node.js 0.12"
 NODEREPO="pub_0.12"
 NODEPKG="nodejs"
 
@@ -75,11 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-echo "X${NODENAME} == XNode.js v5.x"
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -91,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -175,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js v0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -194,28 +135,27 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
 if [ ! -x /bin/rpm ]; then
-  print_status "\
-You don't appear to be running an Enterprise Linux based \
-system, please contact NodeSource at \
-https://github.com/nodesource/distributions/issues if you think this \
-is incorrect or would like your distribution to be considered for \
-support.\
-"
+  print_status """You don't appear to be running an Enterprise Linux based system,
+please contact NodeSource at https://github.com/nodesource/distributions/issues
+if you think this is incorrect or would like your distribution to be considered
+for support.
+"""
   exit 1
 fi
 
@@ -342,15 +282,14 @@ if [ "$DIST_TYPE" == "el" ] && [ "$DIST_VERSION" == "5" ]; then
       exit 1
     fi
 
-    print_status "\
-The EPEL (Extra Packages for Enterprise Linux) repository is a\n\
-prerequisite for installing Node.js on your operating system. Please\n\
-add it and re-run this setup script.\n\
-\n\
-The EPEL repository RPM is available at:\n\
-  ${epel_url}${epel}\n\
-You can try installing with: \`rpm -ivh <url>\`\
-"
+    print_status """The EPEL (Extra Packages for Enterprise Linux) repository is a
+prerequisite for installing Node.js on your operating system. Please
+add it and re-run this setup script.
+
+The EPEL repository RPM is available at:
+  ${epel_url}${epel}
+You can try installing with: \`rpm -ivh <url>\`
+"""
 
     exit 1
   fi
@@ -385,22 +324,19 @@ EXISTING_NODE=$(rpm -qa 'node|npm|iojs' | grep -v nodesource)
 
 if [ "X${EXISTING_NODE}" != "X" ]; then
 
-  print_status "\
-Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
-"
+  print_status """Your system appears to already have Node.js installed from an alternative source.
+Run \`${bold}sudo yum remove -y ${NODEPKG} npm${normal}\` to remove these first.
+"""
 
 fi
 
-node_deprecation_warning
-
-print_status "\
-Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
-You may also need development tools to build native addons:\n\
-  \`yum install -y gcc-c++ make\`\
-"
-
-## Alternative to install dev tools: `yum groupinstall 'Development Tools'
+print_status """Run \`${bold}sudo yum install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm.
+## You may also need development tools to build native addons:
+     sudo yum install gcc-c++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | sudo tee /etc/yum.repos.d/yarn.repo
+     sudo yum install yarn
+"""
 
 exit 0
 

--- a/rpm/setup_10.x
+++ b/rpm/setup_10.x
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v10.x Dubnium repo onto an
+# Script to install the NodeSource Node.js 10.x repo onto an
 # Enterprise Linux or Fedora Core based system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -14,8 +14,8 @@
 #
 
 SCRSUFFIX="_10.x"
-NODENAME="Node.js v10.x Dubnium"
-NODEREPO="node_10.x"
+NODENAME="Node.js 10.x"
+NODEREPO="pub_10.x"
 NODEPKG="nodejs"
 
 print_status() {
@@ -75,11 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-echo "X${NODENAME} == XNode.js v5.x"
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -91,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -175,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js v0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -194,28 +135,27 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
 if [ ! -x /bin/rpm ]; then
-  print_status "\
-You don't appear to be running an Enterprise Linux based \
-system, please contact NodeSource at \
-https://github.com/nodesource/distributions/issues if you think this \
-is incorrect or would like your distribution to be considered for \
-support.\
-"
+  print_status """You don't appear to be running an Enterprise Linux based system,
+please contact NodeSource at https://github.com/nodesource/distributions/issues
+if you think this is incorrect or would like your distribution to be considered
+for support.
+"""
   exit 1
 fi
 
@@ -342,15 +282,14 @@ if [ "$DIST_TYPE" == "el" ] && [ "$DIST_VERSION" == "5" ]; then
       exit 1
     fi
 
-    print_status "\
-The EPEL (Extra Packages for Enterprise Linux) repository is a\n\
-prerequisite for installing Node.js on your operating system. Please\n\
-add it and re-run this setup script.\n\
-\n\
-The EPEL repository RPM is available at:\n\
-  ${epel_url}${epel}\n\
-You can try installing with: \`rpm -ivh <url>\`\
-"
+    print_status """The EPEL (Extra Packages for Enterprise Linux) repository is a
+prerequisite for installing Node.js on your operating system. Please
+add it and re-run this setup script.
+
+The EPEL repository RPM is available at:
+  ${epel_url}${epel}
+You can try installing with: \`rpm -ivh <url>\`
+"""
 
     exit 1
   fi
@@ -385,22 +324,19 @@ EXISTING_NODE=$(rpm -qa 'node|npm|iojs' | grep -v nodesource)
 
 if [ "X${EXISTING_NODE}" != "X" ]; then
 
-  print_status "\
-Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
-"
+  print_status """Your system appears to already have Node.js installed from an alternative source.
+Run \`${bold}sudo yum remove -y ${NODEPKG} npm${normal}\` to remove these first.
+"""
 
 fi
 
-node_deprecation_warning
-
-print_status "\
-Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
-You may also need development tools to build native addons:\n\
-  \`yum install -y gcc-c++ make\`\
-"
-
-## Alternative to install dev tools: `yum groupinstall 'Development Tools'
+print_status """Run \`${bold}sudo yum install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm.
+## You may also need development tools to build native addons:
+     sudo yum install gcc-c++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | sudo tee /etc/yum.repos.d/yarn.repo
+     sudo yum install yarn
+"""
 
 exit 0
 

--- a/rpm/setup_4.x
+++ b/rpm/setup_4.x
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v4.x LTS Argon repo onto an
+# Script to install the NodeSource Node.js 4.x LTS Argon repo onto an
 # Enterprise Linux or Fedora Core based system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -14,7 +14,7 @@
 #
 
 SCRSUFFIX="_4.x"
-NODENAME="Node.js v4.x LTS Argon"
+NODENAME="Node.js 4.x LTS Argon"
 NODEREPO="pub_4.x"
 NODEPKG="nodejs"
 
@@ -75,11 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-echo "X${NODENAME} == XNode.js v5.x"
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -91,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -175,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js v0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -194,28 +135,27 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
 if [ ! -x /bin/rpm ]; then
-  print_status "\
-You don't appear to be running an Enterprise Linux based \
-system, please contact NodeSource at \
-https://github.com/nodesource/distributions/issues if you think this \
-is incorrect or would like your distribution to be considered for \
-support.\
-"
+  print_status """You don't appear to be running an Enterprise Linux based system,
+please contact NodeSource at https://github.com/nodesource/distributions/issues
+if you think this is incorrect or would like your distribution to be considered
+for support.
+"""
   exit 1
 fi
 
@@ -342,15 +282,14 @@ if [ "$DIST_TYPE" == "el" ] && [ "$DIST_VERSION" == "5" ]; then
       exit 1
     fi
 
-    print_status "\
-The EPEL (Extra Packages for Enterprise Linux) repository is a\n\
-prerequisite for installing Node.js on your operating system. Please\n\
-add it and re-run this setup script.\n\
-\n\
-The EPEL repository RPM is available at:\n\
-  ${epel_url}${epel}\n\
-You can try installing with: \`rpm -ivh <url>\`\
-"
+    print_status """The EPEL (Extra Packages for Enterprise Linux) repository is a
+prerequisite for installing Node.js on your operating system. Please
+add it and re-run this setup script.
+
+The EPEL repository RPM is available at:
+  ${epel_url}${epel}
+You can try installing with: \`rpm -ivh <url>\`
+"""
 
     exit 1
   fi
@@ -385,22 +324,19 @@ EXISTING_NODE=$(rpm -qa 'node|npm|iojs' | grep -v nodesource)
 
 if [ "X${EXISTING_NODE}" != "X" ]; then
 
-  print_status "\
-Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
-"
+  print_status """Your system appears to already have Node.js installed from an alternative source.
+Run \`${bold}sudo yum remove -y ${NODEPKG} npm${normal}\` to remove these first.
+"""
 
 fi
 
-node_deprecation_warning
-
-print_status "\
-Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
-You may also need development tools to build native addons:\n\
-  \`yum install -y gcc-c++ make\`\
-"
-
-## Alternative to install dev tools: `yum groupinstall 'Development Tools'
+print_status """Run \`${bold}sudo yum install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm.
+## You may also need development tools to build native addons:
+     sudo yum install gcc-c++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | sudo tee /etc/yum.repos.d/yarn.repo
+     sudo yum install yarn
+"""
 
 exit 0
 

--- a/rpm/setup_5.x
+++ b/rpm/setup_5.x
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v5.x repo onto an
+# Script to install the NodeSource Node.js 5.x repo onto an
 # Enterprise Linux or Fedora Core based system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -14,7 +14,7 @@
 #
 
 SCRSUFFIX="_5.x"
-NODENAME="Node.js v5.x"
+NODENAME="Node.js 5.x"
 NODEREPO="pub_5.x"
 NODEPKG="nodejs"
 
@@ -75,11 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-echo "X${NODENAME} == XNode.js v5.x"
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -91,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -175,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js v0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -194,28 +135,27 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
 if [ ! -x /bin/rpm ]; then
-  print_status "\
-You don't appear to be running an Enterprise Linux based \
-system, please contact NodeSource at \
-https://github.com/nodesource/distributions/issues if you think this \
-is incorrect or would like your distribution to be considered for \
-support.\
-"
+  print_status """You don't appear to be running an Enterprise Linux based system,
+please contact NodeSource at https://github.com/nodesource/distributions/issues
+if you think this is incorrect or would like your distribution to be considered
+for support.
+"""
   exit 1
 fi
 
@@ -342,15 +282,14 @@ if [ "$DIST_TYPE" == "el" ] && [ "$DIST_VERSION" == "5" ]; then
       exit 1
     fi
 
-    print_status "\
-The EPEL (Extra Packages for Enterprise Linux) repository is a\n\
-prerequisite for installing Node.js on your operating system. Please\n\
-add it and re-run this setup script.\n\
-\n\
-The EPEL repository RPM is available at:\n\
-  ${epel_url}${epel}\n\
-You can try installing with: \`rpm -ivh <url>\`\
-"
+    print_status """The EPEL (Extra Packages for Enterprise Linux) repository is a
+prerequisite for installing Node.js on your operating system. Please
+add it and re-run this setup script.
+
+The EPEL repository RPM is available at:
+  ${epel_url}${epel}
+You can try installing with: \`rpm -ivh <url>\`
+"""
 
     exit 1
   fi
@@ -385,22 +324,19 @@ EXISTING_NODE=$(rpm -qa 'node|npm|iojs' | grep -v nodesource)
 
 if [ "X${EXISTING_NODE}" != "X" ]; then
 
-  print_status "\
-Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
-"
+  print_status """Your system appears to already have Node.js installed from an alternative source.
+Run \`${bold}sudo yum remove -y ${NODEPKG} npm${normal}\` to remove these first.
+"""
 
 fi
 
-node_deprecation_warning
-
-print_status "\
-Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
-You may also need development tools to build native addons:\n\
-  \`yum install -y gcc-c++ make\`\
-"
-
-## Alternative to install dev tools: `yum groupinstall 'Development Tools'
+print_status """Run \`${bold}sudo yum install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm.
+## You may also need development tools to build native addons:
+     sudo yum install gcc-c++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | sudo tee /etc/yum.repos.d/yarn.repo
+     sudo yum install yarn
+"""
 
 exit 0
 

--- a/rpm/setup_6.x
+++ b/rpm/setup_6.x
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v6.x LTS Boron repo onto an
+# Script to install the NodeSource Node.js 6.x LTS Boron repo onto an
 # Enterprise Linux or Fedora Core based system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -14,7 +14,7 @@
 #
 
 SCRSUFFIX="_6.x"
-NODENAME="Node.js v6.x LTS Boron"
+NODENAME="Node.js 6.x LTS Boron"
 NODEREPO="pub_6.x"
 NODEPKG="nodejs"
 
@@ -75,11 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-echo "X${NODENAME} == XNode.js v5.x"
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -91,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -175,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js v0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -194,28 +135,27 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
 if [ ! -x /bin/rpm ]; then
-  print_status "\
-You don't appear to be running an Enterprise Linux based \
-system, please contact NodeSource at \
-https://github.com/nodesource/distributions/issues if you think this \
-is incorrect or would like your distribution to be considered for \
-support.\
-"
+  print_status """You don't appear to be running an Enterprise Linux based system,
+please contact NodeSource at https://github.com/nodesource/distributions/issues
+if you think this is incorrect or would like your distribution to be considered
+for support.
+"""
   exit 1
 fi
 
@@ -342,15 +282,14 @@ if [ "$DIST_TYPE" == "el" ] && [ "$DIST_VERSION" == "5" ]; then
       exit 1
     fi
 
-    print_status "\
-The EPEL (Extra Packages for Enterprise Linux) repository is a\n\
-prerequisite for installing Node.js on your operating system. Please\n\
-add it and re-run this setup script.\n\
-\n\
-The EPEL repository RPM is available at:\n\
-  ${epel_url}${epel}\n\
-You can try installing with: \`rpm -ivh <url>\`\
-"
+    print_status """The EPEL (Extra Packages for Enterprise Linux) repository is a
+prerequisite for installing Node.js on your operating system. Please
+add it and re-run this setup script.
+
+The EPEL repository RPM is available at:
+  ${epel_url}${epel}
+You can try installing with: \`rpm -ivh <url>\`
+"""
 
     exit 1
   fi
@@ -385,22 +324,19 @@ EXISTING_NODE=$(rpm -qa 'node|npm|iojs' | grep -v nodesource)
 
 if [ "X${EXISTING_NODE}" != "X" ]; then
 
-  print_status "\
-Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
-"
+  print_status """Your system appears to already have Node.js installed from an alternative source.
+Run \`${bold}sudo yum remove -y ${NODEPKG} npm${normal}\` to remove these first.
+"""
 
 fi
 
-node_deprecation_warning
-
-print_status "\
-Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
-You may also need development tools to build native addons:\n\
-  \`yum install -y gcc-c++ make\`\
-"
-
-## Alternative to install dev tools: `yum groupinstall 'Development Tools'
+print_status """Run \`${bold}sudo yum install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm.
+## You may also need development tools to build native addons:
+     sudo yum install gcc-c++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | sudo tee /etc/yum.repos.d/yarn.repo
+     sudo yum install yarn
+"""
 
 exit 0
 

--- a/rpm/setup_7.x
+++ b/rpm/setup_7.x
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v7.x repo onto an
+# Script to install the NodeSource Node.js 7.x repo onto an
 # Enterprise Linux or Fedora Core based system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -14,7 +14,7 @@
 #
 
 SCRSUFFIX="_7.x"
-NODENAME="Node.js v7.x"
+NODENAME="Node.js 7.x"
 NODEREPO="pub_7.x"
 NODEPKG="nodejs"
 
@@ -75,11 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-echo "X${NODENAME} == XNode.js v5.x"
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -91,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -175,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js v0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -194,28 +135,27 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
 if [ ! -x /bin/rpm ]; then
-  print_status "\
-You don't appear to be running an Enterprise Linux based \
-system, please contact NodeSource at \
-https://github.com/nodesource/distributions/issues if you think this \
-is incorrect or would like your distribution to be considered for \
-support.\
-"
+  print_status """You don't appear to be running an Enterprise Linux based system,
+please contact NodeSource at https://github.com/nodesource/distributions/issues
+if you think this is incorrect or would like your distribution to be considered
+for support.
+"""
   exit 1
 fi
 
@@ -342,15 +282,14 @@ if [ "$DIST_TYPE" == "el" ] && [ "$DIST_VERSION" == "5" ]; then
       exit 1
     fi
 
-    print_status "\
-The EPEL (Extra Packages for Enterprise Linux) repository is a\n\
-prerequisite for installing Node.js on your operating system. Please\n\
-add it and re-run this setup script.\n\
-\n\
-The EPEL repository RPM is available at:\n\
-  ${epel_url}${epel}\n\
-You can try installing with: \`rpm -ivh <url>\`\
-"
+    print_status """The EPEL (Extra Packages for Enterprise Linux) repository is a
+prerequisite for installing Node.js on your operating system. Please
+add it and re-run this setup script.
+
+The EPEL repository RPM is available at:
+  ${epel_url}${epel}
+You can try installing with: \`rpm -ivh <url>\`
+"""
 
     exit 1
   fi
@@ -385,22 +324,19 @@ EXISTING_NODE=$(rpm -qa 'node|npm|iojs' | grep -v nodesource)
 
 if [ "X${EXISTING_NODE}" != "X" ]; then
 
-  print_status "\
-Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
-"
+  print_status """Your system appears to already have Node.js installed from an alternative source.
+Run \`${bold}sudo yum remove -y ${NODEPKG} npm${normal}\` to remove these first.
+"""
 
 fi
 
-node_deprecation_warning
-
-print_status "\
-Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
-You may also need development tools to build native addons:\n\
-  \`yum install -y gcc-c++ make\`\
-"
-
-## Alternative to install dev tools: `yum groupinstall 'Development Tools'
+print_status """Run \`${bold}sudo yum install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm.
+## You may also need development tools to build native addons:
+     sudo yum install gcc-c++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | sudo tee /etc/yum.repos.d/yarn.repo
+     sudo yum install yarn
+"""
 
 exit 0
 

--- a/rpm/setup_9.x
+++ b/rpm/setup_9.x
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js v9.x repo onto an
+# Script to install the NodeSource Node.js 9.x repo onto an
 # Enterprise Linux or Fedora Core based system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -14,7 +14,7 @@
 #
 
 SCRSUFFIX="_9.x"
-NODENAME="Node.js v9.x"
+NODENAME="Node.js 9.x"
 NODEREPO="pub_9.x"
 NODEPKG="nodejs"
 
@@ -75,11 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-echo "X${NODENAME} == XNode.js v5.x"
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -91,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -175,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js v0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -194,28 +135,27 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
 if [ ! -x /bin/rpm ]; then
-  print_status "\
-You don't appear to be running an Enterprise Linux based \
-system, please contact NodeSource at \
-https://github.com/nodesource/distributions/issues if you think this \
-is incorrect or would like your distribution to be considered for \
-support.\
-"
+  print_status """You don't appear to be running an Enterprise Linux based system,
+please contact NodeSource at https://github.com/nodesource/distributions/issues
+if you think this is incorrect or would like your distribution to be considered
+for support.
+"""
   exit 1
 fi
 
@@ -342,15 +282,14 @@ if [ "$DIST_TYPE" == "el" ] && [ "$DIST_VERSION" == "5" ]; then
       exit 1
     fi
 
-    print_status "\
-The EPEL (Extra Packages for Enterprise Linux) repository is a\n\
-prerequisite for installing Node.js on your operating system. Please\n\
-add it and re-run this setup script.\n\
-\n\
-The EPEL repository RPM is available at:\n\
-  ${epel_url}${epel}\n\
-You can try installing with: \`rpm -ivh <url>\`\
-"
+    print_status """The EPEL (Extra Packages for Enterprise Linux) repository is a
+prerequisite for installing Node.js on your operating system. Please
+add it and re-run this setup script.
+
+The EPEL repository RPM is available at:
+  ${epel_url}${epel}
+You can try installing with: \`rpm -ivh <url>\`
+"""
 
     exit 1
   fi
@@ -385,22 +324,19 @@ EXISTING_NODE=$(rpm -qa 'node|npm|iojs' | grep -v nodesource)
 
 if [ "X${EXISTING_NODE}" != "X" ]; then
 
-  print_status "\
-Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
-"
+  print_status """Your system appears to already have Node.js installed from an alternative source.
+Run \`${bold}sudo yum remove -y ${NODEPKG} npm${normal}\` to remove these first.
+"""
 
 fi
 
-node_deprecation_warning
-
-print_status "\
-Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
-You may also need development tools to build native addons:\n\
-  \`yum install -y gcc-c++ make\`\
-"
-
-## Alternative to install dev tools: `yum groupinstall 'Development Tools'
+print_status """Run \`${bold}sudo yum install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm.
+## You may also need development tools to build native addons:
+     sudo yum install gcc-c++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | sudo tee /etc/yum.repos.d/yarn.repo
+     sudo yum install yarn
+"""
 
 exit 0
 

--- a/rpm/setup_iojs_1.x
+++ b/rpm/setup_iojs_1.x
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource io.js v1.x repo onto an
+# Script to install the NodeSource io.js 1.x repo onto an
 # Enterprise Linux or Fedora Core based system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -14,7 +14,7 @@
 #
 
 SCRSUFFIX="_iojs_1.x"
-NODENAME="io.js v1.x"
+NODENAME="io.js 1.x"
 NODEREPO="pub_iojs_1.x"
 NODEPKG="iojs"
 
@@ -75,11 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-echo "X${NODENAME} == XNode.js v5.x"
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -91,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -175,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js v0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -194,28 +135,27 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
 if [ ! -x /bin/rpm ]; then
-  print_status "\
-You don't appear to be running an Enterprise Linux based \
-system, please contact NodeSource at \
-https://github.com/nodesource/distributions/issues if you think this \
-is incorrect or would like your distribution to be considered for \
-support.\
-"
+  print_status """You don't appear to be running an Enterprise Linux based system,
+please contact NodeSource at https://github.com/nodesource/distributions/issues
+if you think this is incorrect or would like your distribution to be considered
+for support.
+"""
   exit 1
 fi
 
@@ -342,15 +282,14 @@ if [ "$DIST_TYPE" == "el" ] && [ "$DIST_VERSION" == "5" ]; then
       exit 1
     fi
 
-    print_status "\
-The EPEL (Extra Packages for Enterprise Linux) repository is a\n\
-prerequisite for installing Node.js on your operating system. Please\n\
-add it and re-run this setup script.\n\
-\n\
-The EPEL repository RPM is available at:\n\
-  ${epel_url}${epel}\n\
-You can try installing with: \`rpm -ivh <url>\`\
-"
+    print_status """The EPEL (Extra Packages for Enterprise Linux) repository is a
+prerequisite for installing Node.js on your operating system. Please
+add it and re-run this setup script.
+
+The EPEL repository RPM is available at:
+  ${epel_url}${epel}
+You can try installing with: \`rpm -ivh <url>\`
+"""
 
     exit 1
   fi
@@ -385,22 +324,19 @@ EXISTING_NODE=$(rpm -qa 'node|npm|iojs' | grep -v nodesource)
 
 if [ "X${EXISTING_NODE}" != "X" ]; then
 
-  print_status "\
-Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
-"
+  print_status """Your system appears to already have Node.js installed from an alternative source.
+Run \`${bold}sudo yum remove -y ${NODEPKG} npm${normal}\` to remove these first.
+"""
 
 fi
 
-node_deprecation_warning
-
-print_status "\
-Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
-You may also need development tools to build native addons:\n\
-  \`yum install -y gcc-c++ make\`\
-"
-
-## Alternative to install dev tools: `yum groupinstall 'Development Tools'
+print_status """Run \`${bold}sudo yum install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm.
+## You may also need development tools to build native addons:
+     sudo yum install gcc-c++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | sudo tee /etc/yum.repos.d/yarn.repo
+     sudo yum install yarn
+"""
 
 exit 0
 

--- a/rpm/setup_iojs_2.x
+++ b/rpm/setup_iojs_2.x
@@ -3,7 +3,7 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource io.js v2.x repo onto an
+# Script to install the NodeSource io.js 2.x repo onto an
 # Enterprise Linux or Fedora Core based system.
 #
 # Run as root or insert `sudo -E` before `bash`:
@@ -14,7 +14,7 @@
 #
 
 SCRSUFFIX="_iojs_2.x"
-NODENAME="io.js v2.x"
+NODENAME="io.js 2.x"
 NODEREPO="pub_iojs_2.x"
 NODEPKG="iojs"
 
@@ -75,11 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-echo "X${NODENAME} == XNode.js v5.x"
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -91,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -175,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js v0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -194,28 +135,27 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
 if [ ! -x /bin/rpm ]; then
-  print_status "\
-You don't appear to be running an Enterprise Linux based \
-system, please contact NodeSource at \
-https://github.com/nodesource/distributions/issues if you think this \
-is incorrect or would like your distribution to be considered for \
-support.\
-"
+  print_status """You don't appear to be running an Enterprise Linux based system,
+please contact NodeSource at https://github.com/nodesource/distributions/issues
+if you think this is incorrect or would like your distribution to be considered
+for support.
+"""
   exit 1
 fi
 
@@ -342,15 +282,14 @@ if [ "$DIST_TYPE" == "el" ] && [ "$DIST_VERSION" == "5" ]; then
       exit 1
     fi
 
-    print_status "\
-The EPEL (Extra Packages for Enterprise Linux) repository is a\n\
-prerequisite for installing Node.js on your operating system. Please\n\
-add it and re-run this setup script.\n\
-\n\
-The EPEL repository RPM is available at:\n\
-  ${epel_url}${epel}\n\
-You can try installing with: \`rpm -ivh <url>\`\
-"
+    print_status """The EPEL (Extra Packages for Enterprise Linux) repository is a
+prerequisite for installing Node.js on your operating system. Please
+add it and re-run this setup script.
+
+The EPEL repository RPM is available at:
+  ${epel_url}${epel}
+You can try installing with: \`rpm -ivh <url>\`
+"""
 
     exit 1
   fi
@@ -385,22 +324,19 @@ EXISTING_NODE=$(rpm -qa 'node|npm|iojs' | grep -v nodesource)
 
 if [ "X${EXISTING_NODE}" != "X" ]; then
 
-  print_status "\
-Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
-"
+  print_status """Your system appears to already have Node.js installed from an alternative source.
+Run \`${bold}sudo yum remove -y ${NODEPKG} npm${normal}\` to remove these first.
+"""
 
 fi
 
-node_deprecation_warning
-
-print_status "\
-Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
-You may also need development tools to build native addons:\n\
-  \`yum install -y gcc-c++ make\`\
-"
-
-## Alternative to install dev tools: `yum groupinstall 'Development Tools'
+print_status """Run \`${bold}sudo yum install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm.
+## You may also need development tools to build native addons:
+     sudo yum install gcc-c++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | sudo tee /etc/yum.repos.d/yarn.repo
+     sudo yum install yarn
+"""
 
 exit 0
 

--- a/rpm/setup_iojs_3.x
+++ b/rpm/setup_iojs_3.x
@@ -3,20 +3,20 @@
 # Discussion, issues and change requests at:
 #   https://github.com/nodesource/distributions
 #
-# Script to install the NodeSource Node.js 8.x LTS Carbon repo onto an
+# Script to install the NodeSource io.js 3.x repo onto an
 # Enterprise Linux or Fedora Core based system.
 #
 # Run as root or insert `sudo -E` before `bash`:
 #
-# curl -sL https://rpm.nodesource.com/setup_8.x | bash -
+# curl -sL https://rpm.nodesource.com/setup_iojs_3.x | bash -
 #   or
-# wget -qO- https://rpm.nodesource.com/setup_8.x | bash -
+# wget -qO- https://rpm.nodesource.com/setup_iojs_3.x | bash -
 #
 
-SCRSUFFIX="_8.x"
-NODENAME="Node.js 8.x LTS Carbon"
-NODEREPO="pub_8.x"
-NODEPKG="nodejs"
+SCRSUFFIX="_iojs_3.x"
+NODENAME="io.js 3.x"
+NODEREPO="pub_iojs_3.x"
+NODEPKG="iojs"
 
 print_status() {
   local outp=$(echo "$1") # | sed -r 's/\\n/\\n## /mg')

--- a/rpm/src/_setup.sh
+++ b/rpm/src/_setup.sh
@@ -75,11 +75,14 @@ exec_cmd() {
 }
 
 node_deprecation_warning() {
-echo "X${NODENAME} == XNode.js v5.x"
-    if [[ "X${NODENAME}" == "Xio.js v1.x" ||
-          "X${NODENAME}" == "Xio.js v2.x" ||
-          "X${NODENAME}" == "Xio.js v3.x" ||
-          "X${NODENAME}" == "XNode.js v5.x" ]]; then
+    if [[ "X${NODENAME}" == "Xio.js 1.x" ||
+          "X${NODENAME}" == "Xio.js 2.x" ||
+          "X${NODENAME}" == "Xio.js 3.x" ||
+          "X${NODENAME}" == "XNode.js 0.10" ||
+          "X${NODENAME}" == "XNode.js 0.12" ||
+          "X${NODENAME}" == "XNode.js 4.x LTS Argon" ||
+          "X${NODENAME}" == "XNode.js 5.x" ||
+          "X${NODENAME}" == "XNode.js 7.x" ]]; then
 
         print_bold \
 "                            DEPRECATION WARNING                            " "\
@@ -91,82 +94,21 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-        echo
-        echo "Continuing in 10 seconds ..."
-        echo
-        sleep 10
-
-    elif [ "X${NODENAME}" == "XNode.js v0.10" ]; then
-
-        print_bold \
-"                     NODE.JS v0.10 DEPRECATION WARNING                      " "\
-Node.js v0.10 will cease to be actively supported in ${bold}October 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
   are supported and how to use the install scripts.
     ${bold}https://github.com/nodesource/distributions${normal}
 "
-
         echo
-        echo "Continuing in 5 seconds ..."
+        echo "Continuing in 20 seconds ..."
         echo
-        sleep 5
-
-    elif [ "X${NODENAME}" == "XNode.js v0.12" ]; then
-
-        print_bold \
-"                     NODE.JS v0.12 DEPRECATION WARNING                      " "\
-Node.js v0.12 will cease to be actively supported ${bold}at the end of 2016${normal}.
-
-  This means you will not continue to receive security or critical stability
-  updates for this version of Node.js beyond that time.
-
-  You should begin migration to a newer version of Node.js as soon as
-  possible. Use the installation script that corresponds to the version of
-  Node.js you wish to install. e.g.
-
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
-
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
-
-  The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
-  information about which versions of Node.js and which Linux distributions
-  are supported and how to use the install scripts.
-    ${bold}https://github.com/nodesource/distributions${normal}
-"
-
-        echo
-        echo "Continuing in 3 seconds ..."
-        echo
-        sleep 3
-
+        sleep 20
     fi
 }
 
@@ -175,17 +117,16 @@ script_deprecation_warning() {
         print_bold \
 "                         SCRIPT DEPRECATION WARNING                         " "\
 This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used to
-  install Node.js v0.10, is being deprecated and will eventually be made
-  inactive.
+  install Node.js v0.10, is deprecated and will eventually be made inactive.
 
   You should use the script that corresponds to the version of Node.js you
   wish to install. e.g.
 
-   * ${green}https://rpm.nodesource.com/setup_4.x — Node.js v4 LTS \"Argon\"${normal} (recommended)
-   * ${green}https://rpm.nodesource.com/setup_6.x — Node.js v6 Current${normal}
+   * ${green}https://deb.nodesource.com/setup_8.x — Node.js v8 LTS \"Carbon\"${normal} (recommended)
+   * ${green}https://deb.nodesource.com/setup_10.x — Node.js v10 Current${normal}
 
-  Please see ${bold}https://github.com/nodejs/LTS/${normal} for details about which version
-  may be appropriate for you.
+  Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
+  version may be appropriate for you.
 
   The ${bold}NodeSource${normal} Node.js Linux distributions GitHub repository contains
   information about which versions of Node.js and which Linux distributions
@@ -194,28 +135,27 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
 "
 
         echo
-        echo "Continuing in 10 seconds (press Ctrl-C to abort) ..."
+        echo "Continuing in 20 seconds (press Ctrl-C to abort) ..."
         echo
-        sleep 10
+        sleep 20
     fi
 }
 
 setup() {
 
 script_deprecation_warning
+node_deprecation_warning
 
 print_status "Installing the NodeSource ${NODENAME} repo..."
 
 print_status "Inspecting system..."
 
 if [ ! -x /bin/rpm ]; then
-  print_status "\
-You don't appear to be running an Enterprise Linux based \
-system, please contact NodeSource at \
-https://github.com/nodesource/distributions/issues if you think this \
-is incorrect or would like your distribution to be considered for \
-support.\
-"
+  print_status """You don't appear to be running an Enterprise Linux based system,
+please contact NodeSource at https://github.com/nodesource/distributions/issues
+if you think this is incorrect or would like your distribution to be considered
+for support.
+"""
   exit 1
 fi
 
@@ -342,15 +282,14 @@ if [ "$DIST_TYPE" == "el" ] && [ "$DIST_VERSION" == "5" ]; then
       exit 1
     fi
 
-    print_status "\
-The EPEL (Extra Packages for Enterprise Linux) repository is a\n\
-prerequisite for installing Node.js on your operating system. Please\n\
-add it and re-run this setup script.\n\
-\n\
-The EPEL repository RPM is available at:\n\
-  ${epel_url}${epel}\n\
-You can try installing with: \`rpm -ivh <url>\`\
-"
+    print_status """The EPEL (Extra Packages for Enterprise Linux) repository is a
+prerequisite for installing Node.js on your operating system. Please
+add it and re-run this setup script.
+
+The EPEL repository RPM is available at:
+  ${epel_url}${epel}
+You can try installing with: \`rpm -ivh <url>\`
+"""
 
     exit 1
   fi
@@ -385,22 +324,19 @@ EXISTING_NODE=$(rpm -qa 'node|npm|iojs' | grep -v nodesource)
 
 if [ "X${EXISTING_NODE}" != "X" ]; then
 
-  print_status "\
-Your system appears to already have Node.js installed from an alternative source.\n\
-Run \`\033[1myum remove -y ${NODEPKG} npm\033[22m\` (as root) to remove these first.\
-"
+  print_status """Your system appears to already have Node.js installed from an alternative source.
+Run \`${bold}sudo yum remove -y ${NODEPKG} npm${normal}\` to remove these first.
+"""
 
 fi
 
-node_deprecation_warning
-
-print_status "\
-Run \`\033[1myum install -y ${NODEPKG}\033[22m\` (as root) to install ${NODENAME} and npm.\n\
-You may also need development tools to build native addons:\n\
-  \`yum install -y gcc-c++ make\`\
-"
-
-## Alternative to install dev tools: `yum groupinstall 'Development Tools'
+print_status """Run \`${bold}sudo yum install -y ${NODEPKG}${normal}\` to install ${NODENAME} and npm.
+## You may also need development tools to build native addons:
+     sudo yum install gcc-c++ make
+## To install the Yarn package manager, run:
+     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | sudo tee /etc/yum.repos.d/yarn.repo
+     sudo yum install yarn
+"""
 
 exit 0
 

--- a/rpm/src/build.sh
+++ b/rpm/src/build.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
 
-RELEASES=( "pub_0.10::nodejs:Node.js v0.10"
-           "pub_0.10:_0.10:nodejs:Node.js v0.10"
-           "pub_0.12:_0.12:nodejs:Node.js v0.12"
-           "pub_iojs_1.x:_iojs_1.x:iojs:io.js v1.x"
-           "pub_iojs_2.x:_iojs_2.x:iojs:io.js v2.x"
-           "pub_4.x:_4.x:nodejs:Node.js v4.x LTS Argon"
-           "pub_5.x:_5.x:nodejs:Node.js v5.x"
-           "pub_6.x:_6.x:nodejs:Node.js v6.x LTS Boron"
-           "pub_7.x:_7.x:nodejs:Node.js v7.x"
-           "pub_8.x:_8.x:nodejs:Node.js v8.x LTS Carbon"
-           "pub_9.x:_9.x:nodejs:Node.js v9.x"
-           "node_10.x:_10.x:nodejs:Node.js v10.x Dubnium"
+RELEASES=( "pub_0.10::nodejs:Node.js 0.10"
+           "pub_0.10:_0.10:nodejs:Node.js 0.10"
+           "pub_0.12:_0.12:nodejs:Node.js 0.12"
+           "pub_iojs_1.x:_iojs_1.x:iojs:io.js 1.x"
+           "pub_iojs_2.x:_iojs_2.x:iojs:io.js 2.x"
+           "pub_iojs_3.x:_iojs_3.x:iojs:io.js 3.x"
+           "pub_4.x:_4.x:nodejs:Node.js 4.x LTS Argon"
+           "pub_5.x:_5.x:nodejs:Node.js 5.x"
+           "pub_6.x:_6.x:nodejs:Node.js 6.x LTS Boron"
+           "pub_7.x:_7.x:nodejs:Node.js 7.x"
+           "pub_8.x:_8.x:nodejs:Node.js 8.x LTS Carbon"
+           "pub_9.x:_9.x:nodejs:Node.js 9.x"
+           "pub_10.x:_10.x:nodejs:Node.js 10.x"
          )
 SOURCE=_setup.sh
 DEST=../setup


### PR DESCRIPTION
* deprecate 0.10, 0.12, 4, 7 (single deprecation warning—note that 4 still has a week to go so this is a little bit early)
* add Yarn instructions
* drop `v` from version identifiers
* assume sudo is available (post-wheezy this is a good bet)

deprecation:
<img width="754" alt="screenshot 2018-04-24 22 10 46" src="https://user-images.githubusercontent.com/495647/39186250-235fe8c8-480d-11e8-9694-11cadbfa5e95.png">

deb final instructions:
<img width="947" alt="screenshot 2018-04-24 22 10 04" src="https://user-images.githubusercontent.com/495647/39186251-23ba7ab8-480d-11e8-8bd1-47d6b9b255ac.png">

rpm final instructions:
<img width="810" alt="screenshot 2018-04-24 22 07 19" src="https://user-images.githubusercontent.com/495647/39186252-2416433e-480d-11e8-9813-5a1fa70e7675.png">
