### PR TITLE
Update setup_8.x

### DIFF
--- a/rpm/setup_8.x
+++ b/rpm/setup_8.x
@@ -173,6 +173,8 @@ if [ "X${UNAME_ARCH}" == "Xi686" ]; then
   DIST_ARCH=i386
 elif [ "X${UNAME_ARCH}" == "Xx86_64" ]; then
   DIST_ARCH=x86_64
+elif [ "X${UNAME_ARCH}" == "Xaarch64" ]; then
+  DIST_ARCH=aarch64
 else
 
   print_status "\


### PR DESCRIPTION
Added aarch64

There is no support for aarch64 in RHEL 7

I built the binary for aarch64
```
[root @ hermes aarch64] # ls -1
nodejs-8.4.0-1nodesource.el7.aarch64.rpm
nodejs-debuginfo-8.4.0-1nodesource.el7.aarch64.rpm
nodejs-devel-8.4.0-1nodesource.el7.aarch64.rpm
[root @ hermes aarch64] #
````
Can I upload the files?

Best Regards,
Fábio Sbano