### PR TITLE
deb: install gnupg package if it's not there

### DIFF
--- a/deb/setup
+++ b/deb/setup
@@ -170,6 +170,12 @@ if [ ! -x /usr/bin/curl ] && [ ! -x /usr/bin/wget ]; then
     PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} curl"
 fi
 
+# Used by apt-key to add new keys
+
+if [ ! -x /usr/bin/gpg ]; then
+    PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} gnupg"
+fi
+
 # Populating Cache
 print_status "Populating apt-get cache..."
 exec_cmd 'apt-get update'

--- a/deb/setup_0.10
+++ b/deb/setup_0.10
@@ -170,6 +170,12 @@ if [ ! -x /usr/bin/curl ] && [ ! -x /usr/bin/wget ]; then
     PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} curl"
 fi
 
+# Used by apt-key to add new keys
+
+if [ ! -x /usr/bin/gpg ]; then
+    PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} gnupg"
+fi
+
 # Populating Cache
 print_status "Populating apt-get cache..."
 exec_cmd 'apt-get update'

--- a/deb/setup_0.12
+++ b/deb/setup_0.12
@@ -170,6 +170,12 @@ if [ ! -x /usr/bin/curl ] && [ ! -x /usr/bin/wget ]; then
     PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} curl"
 fi
 
+# Used by apt-key to add new keys
+
+if [ ! -x /usr/bin/gpg ]; then
+    PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} gnupg"
+fi
+
 # Populating Cache
 print_status "Populating apt-get cache..."
 exec_cmd 'apt-get update'

--- a/deb/setup_10.x
+++ b/deb/setup_10.x
@@ -170,6 +170,12 @@ if [ ! -x /usr/bin/curl ] && [ ! -x /usr/bin/wget ]; then
     PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} curl"
 fi
 
+# Used by apt-key to add new keys
+
+if [ ! -x /usr/bin/gpg ]; then
+    PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} gnupg"
+fi
+
 # Populating Cache
 print_status "Populating apt-get cache..."
 exec_cmd 'apt-get update'

--- a/deb/setup_11.x
+++ b/deb/setup_11.x
@@ -170,6 +170,12 @@ if [ ! -x /usr/bin/curl ] && [ ! -x /usr/bin/wget ]; then
     PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} curl"
 fi
 
+# Used by apt-key to add new keys
+
+if [ ! -x /usr/bin/gpg ]; then
+    PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} gnupg"
+fi
+
 # Populating Cache
 print_status "Populating apt-get cache..."
 exec_cmd 'apt-get update'

--- a/deb/setup_4.x
+++ b/deb/setup_4.x
@@ -170,6 +170,12 @@ if [ ! -x /usr/bin/curl ] && [ ! -x /usr/bin/wget ]; then
     PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} curl"
 fi
 
+# Used by apt-key to add new keys
+
+if [ ! -x /usr/bin/gpg ]; then
+    PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} gnupg"
+fi
+
 # Populating Cache
 print_status "Populating apt-get cache..."
 exec_cmd 'apt-get update'

--- a/deb/setup_5.x
+++ b/deb/setup_5.x
@@ -170,6 +170,12 @@ if [ ! -x /usr/bin/curl ] && [ ! -x /usr/bin/wget ]; then
     PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} curl"
 fi
 
+# Used by apt-key to add new keys
+
+if [ ! -x /usr/bin/gpg ]; then
+    PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} gnupg"
+fi
+
 # Populating Cache
 print_status "Populating apt-get cache..."
 exec_cmd 'apt-get update'

--- a/deb/setup_6.x
+++ b/deb/setup_6.x
@@ -170,6 +170,12 @@ if [ ! -x /usr/bin/curl ] && [ ! -x /usr/bin/wget ]; then
     PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} curl"
 fi
 
+# Used by apt-key to add new keys
+
+if [ ! -x /usr/bin/gpg ]; then
+    PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} gnupg"
+fi
+
 # Populating Cache
 print_status "Populating apt-get cache..."
 exec_cmd 'apt-get update'

--- a/deb/setup_7.x
+++ b/deb/setup_7.x
@@ -170,6 +170,12 @@ if [ ! -x /usr/bin/curl ] && [ ! -x /usr/bin/wget ]; then
     PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} curl"
 fi
 
+# Used by apt-key to add new keys
+
+if [ ! -x /usr/bin/gpg ]; then
+    PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} gnupg"
+fi
+
 # Populating Cache
 print_status "Populating apt-get cache..."
 exec_cmd 'apt-get update'

--- a/deb/setup_8.x
+++ b/deb/setup_8.x
@@ -170,6 +170,12 @@ if [ ! -x /usr/bin/curl ] && [ ! -x /usr/bin/wget ]; then
     PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} curl"
 fi
 
+# Used by apt-key to add new keys
+
+if [ ! -x /usr/bin/gpg ]; then
+    PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} gnupg"
+fi
+
 # Populating Cache
 print_status "Populating apt-get cache..."
 exec_cmd 'apt-get update'

--- a/deb/setup_9.x
+++ b/deb/setup_9.x
@@ -170,6 +170,12 @@ if [ ! -x /usr/bin/curl ] && [ ! -x /usr/bin/wget ]; then
     PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} curl"
 fi
 
+# Used by apt-key to add new keys
+
+if [ ! -x /usr/bin/gpg ]; then
+    PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} gnupg"
+fi
+
 # Populating Cache
 print_status "Populating apt-get cache..."
 exec_cmd 'apt-get update'

--- a/deb/setup_dev
+++ b/deb/setup_dev
@@ -170,6 +170,12 @@ if [ ! -x /usr/bin/curl ] && [ ! -x /usr/bin/wget ]; then
     PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} curl"
 fi
 
+# Used by apt-key to add new keys
+
+if [ ! -x /usr/bin/gpg ]; then
+    PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} gnupg"
+fi
+
 # Populating Cache
 print_status "Populating apt-get cache..."
 exec_cmd 'apt-get update'

--- a/deb/setup_iojs_1.x
+++ b/deb/setup_iojs_1.x
@@ -170,6 +170,12 @@ if [ ! -x /usr/bin/curl ] && [ ! -x /usr/bin/wget ]; then
     PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} curl"
 fi
 
+# Used by apt-key to add new keys
+
+if [ ! -x /usr/bin/gpg ]; then
+    PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} gnupg"
+fi
+
 # Populating Cache
 print_status "Populating apt-get cache..."
 exec_cmd 'apt-get update'

--- a/deb/setup_iojs_2.x
+++ b/deb/setup_iojs_2.x
@@ -170,6 +170,12 @@ if [ ! -x /usr/bin/curl ] && [ ! -x /usr/bin/wget ]; then
     PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} curl"
 fi
 
+# Used by apt-key to add new keys
+
+if [ ! -x /usr/bin/gpg ]; then
+    PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} gnupg"
+fi
+
 # Populating Cache
 print_status "Populating apt-get cache..."
 exec_cmd 'apt-get update'

--- a/deb/setup_iojs_3.x
+++ b/deb/setup_iojs_3.x
@@ -170,6 +170,12 @@ if [ ! -x /usr/bin/curl ] && [ ! -x /usr/bin/wget ]; then
     PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} curl"
 fi
 
+# Used by apt-key to add new keys
+
+if [ ! -x /usr/bin/gpg ]; then
+    PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} gnupg"
+fi
+
 # Populating Cache
 print_status "Populating apt-get cache..."
 exec_cmd 'apt-get update'

--- a/deb/src/_setup.sh
+++ b/deb/src/_setup.sh
@@ -170,6 +170,12 @@ if [ ! -x /usr/bin/curl ] && [ ! -x /usr/bin/wget ]; then
     PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} curl"
 fi
 
+# Used by apt-key to add new keys
+
+if [ ! -x /usr/bin/gpg ]; then
+    PRE_INSTALL_PKGS="${PRE_INSTALL_PKGS} gnupg"
+fi
+
 # Populating Cache
 print_status "Populating apt-get cache..."
 exec_cmd 'apt-get update'


### PR DESCRIPTION
Debian slim docker images have `apt-key` but not `gnupg` so `apt-key add` fails

Originally reported @ https://github.com/nodejs/nodejs.org/issues/1905, the `php:7` which builds on `debian:stretch-slim` fails the install script because there's no `gnupg`. On Ubuntu it comes from `apt-add-key` which depends on both `apt` (which has `apt-key`) and `gnupg` which is installed on Ubuntu by default I think. On non-slim Debian images it's there too as a default package, but it was stripped out by slim and `apt-key` is there but I guess `apt-key add` isn't intended to work out of the box.

@chrislea over to you