### PR TITLE
Set up repo as root on Enterprise Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,25 +245,28 @@ Run as root on RHEL, CentOS, CloudLinux or Fedora:
 **NodeJS 11.x**
 
 ```text
-curl -sL https://rpm.nodesource.com/setup_11.x | bash -
+curl -sL https://rpm.nodesource.com/setup_11.x | sudo -E bash -
+sudo yum install -y nodejs
 ```
 
 **NodeJS 10.x**
 
 ```text
-curl -sL https://rpm.nodesource.com/setup_10.x | bash -
+curl -sL https://rpm.nodesource.com/setup_10.x | sudo -E bash -
+sudo yum install -y nodejs
 ```
 
 **NodeJS 8.x**
 
 ```text
-curl -sL https://rpm.nodesource.com/setup_8.x | bash -
+curl -sL https://rpm.nodesource.com/setup_8.x | sudo -E bash -
+sudo yum install -y nodejs
 ```
 
 **NodeJS 6.x**
 
 ```text
-curl -sL https://rpm.nodesource.com/setup_6.x | bash -
+curl -sL https://rpm.nodesource.com/setup_6.x | sudo -E bash -
 ```
 
 ***Optional***: install build tools


### PR DESCRIPTION
On Fedora 29, setting up the repo as a non-root user produces this error:

```
## Installing release setup RPM...

+ rpm -i --nosignature --force '/tmp/tmp.xiLusGCjk8'
error: can't create transaction lock on /var/lib/rpm/.rpm.lock (Permission denied)
Error executing command, exiting
```

Including `sudo -E` fixes this problem. I've updated the instructions accordingly. I've also added the command to actually install node. (Other distros include this step, so it seemed like it would be good to be consistent.)

FYI, I've tested these steps with Fedora 29 / Node.js 10.14.1. I haven't tested with other versions of Node, Fedora, or enterprise Linux.

Thank you for maintaining this fantastic resource!