### PR TITLE
Update _setup.sh - Support for ClearOS

### DIFF
--- a/rpm/src/_setup.sh
+++ b/rpm/src/_setup.sh
@@ -185,7 +185,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|clearos|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el


### PR DESCRIPTION
closes #631 

ClearOS is a build of CentOS 7

`rpm -q --whatprovides centos-release` returns appropriate string to parse for version check.