### PR TITLE
Add support for Ubilinux dolcetto

### DIFF
--- a/deb/src/_setup.sh
+++ b/deb/src/_setup.sh
@@ -244,6 +244,7 @@ check_alt "Deepin"        "unstable" "Debian" "sid"
 check_alt "Pardus"        "onyedi"   "Debian" "stretch"
 check_alt "Liquid Lemur"  "lemur-3"  "Debian" "stretch"
 check_alt "Continuum"     "mx-linux" "Debian" "stretch"
+check_alt "Ubilinux"      "dolcetto" "Debian" "stretch"
 
 if [ "X${DISTRO}" == "Xdebian" ]; then
   print_status "Unknown Debian-based distribution, checking /etc/debian_version..."


### PR DESCRIPTION
Ubilinux dolcetto is compatible with Debian stretch. 
Already installed and test with success.