### PR TITLE
Remove note about discontinued Linux OS Korora

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,8 +277,6 @@ NodeSource will continue to maintain the following architectures and may add add
 * **Fedora 31** (64-bit) - **available for Node.js 10.17.0 and later**
 * **Fedora 32** (64-bit)
 
-Equivalent versions of Korora Linux should also be supported.
-
 <a name="rpminstall"></a>
 ### Installation instructions
 


### PR DESCRIPTION
Korora has been discontinued see https://web.archive.org/web/20180506065306/https://kororaproject.org/about/news/time-for-a-break