### PR TITLE
Change curl to wget for Ubuntu/Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ NodeSource will maintain support for stable, testing and unstable releases of De
 
 ```sh
 # Using Ubuntu
-curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+wget -O - https://deb.nodesource.com/setup_14.x | sudo -E bash -
 sudo apt-get install -y nodejs
 
 # Using Debian, as root
-curl -sL https://deb.nodesource.com/setup_14.x | bash -
+wget -O - https://deb.nodesource.com/setup_14.x | bash -
 apt-get install -y nodejs
 ```
 
@@ -147,11 +147,11 @@ apt-get install -y nodejs
 
 ```sh
 # Using Ubuntu
-curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+wget -O - https://deb.nodesource.com/setup_12.x | sudo -E bash -
 sudo apt-get install -y nodejs
 
 # Using Debian, as root
-curl -sL https://deb.nodesource.com/setup_12.x | bash -
+wget -O - https://deb.nodesource.com/setup_12.x | bash -
 apt-get install -y nodejs
 ```
 
@@ -159,11 +159,11 @@ apt-get install -y nodejs
 
 ```sh
 # Using Ubuntu
-curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+wget -O - https://deb.nodesource.com/setup_10.x | sudo -E bash -
 sudo apt-get install -y nodejs
 
 # Using Debian, as root
-curl -sL https://deb.nodesource.com/setup_10.x | bash -
+wget -O - https://deb.nodesource.com/setup_10.x | bash -
 apt-get install -y nodejs
 ```
 
@@ -171,11 +171,11 @@ apt-get install -y nodejs
 
 ```sh
 # Using Ubuntu
-curl -sL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+wget -O - https://deb.nodesource.com/setup_lts.x | sudo -E bash -
 sudo apt-get install -y nodejs
 
 # Using Debian, as root
-curl -sL https://deb.nodesource.com/setup_lts.x | bash -
+wget -O - https://deb.nodesource.com/setup_lts.x | bash -
 apt-get install -y nodejs
 ```
 
@@ -183,11 +183,11 @@ apt-get install -y nodejs
 
 ```sh
 # Using Ubuntu
-curl -sL https://deb.nodesource.com/setup_current.x | sudo -E bash -
+wget -O - https://deb.nodesource.com/setup_current.x | sudo -E bash -
 sudo apt-get install -y nodejs
 
 # Using Debian, as root
-curl -sL https://deb.nodesource.com/setup_current.x | bash -
+wget -O - https://deb.nodesource.com/setup_current.x | bash -
 apt-get install -y nodejs
 ```
 


### PR DESCRIPTION
Ubuntu no longer ships `curl` by default, so it's a better idea to use `wget` instead, to avoid a dependency on `curl`. The `-O -` flag tells `wget` to place the downloaded content into STDOUT rather than a file.