### PR TITLE
Fix CentOS Stream support

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ NodeSource will continue to maintain the following architectures and may add add
 
 * **CentOS 7** (64-bit)
 * **CentOS 8** (64-bit)
+* **CentOS 8 Stream** (64-bit)
 
 **Supported CloudLinux versions:**
 * **CloudLinux 6** (32-bit for Node <= 10.x and 64-bit)

--- a/rpm/setup
+++ b/rpm/setup
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X,  centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 

--- a/rpm/setup_0.10
+++ b/rpm/setup_0.10
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X, centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 

--- a/rpm/setup_0.12
+++ b/rpm/setup_0.12
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X,  centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 

--- a/rpm/setup_10.x
+++ b/rpm/setup_10.x
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X,  centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 

--- a/rpm/setup_11.x
+++ b/rpm/setup_11.x
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X,  centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 

--- a/rpm/setup_12.x
+++ b/rpm/setup_12.x
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X,  centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 

--- a/rpm/setup_13.x
+++ b/rpm/setup_13.x
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X,  centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 

--- a/rpm/setup_14.x
+++ b/rpm/setup_14.x
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X,  centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 

--- a/rpm/setup_4.x
+++ b/rpm/setup_4.x
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X,  centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 

--- a/rpm/setup_5.x
+++ b/rpm/setup_5.x
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X,  centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 

--- a/rpm/setup_6.x
+++ b/rpm/setup_6.x
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X,  centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 

--- a/rpm/setup_7.x
+++ b/rpm/setup_7.x
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X,  centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 

--- a/rpm/setup_8.x
+++ b/rpm/setup_8.x
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X,  centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 

--- a/rpm/setup_9.x
+++ b/rpm/setup_9.x
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X,  centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 

--- a/rpm/setup_current.x
+++ b/rpm/setup_current.x
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X,  centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 

--- a/rpm/setup_iojs_1.x
+++ b/rpm/setup_iojs_1.x
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X,  centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 

--- a/rpm/setup_iojs_2.x
+++ b/rpm/setup_iojs_2.x
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X,  centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 

--- a/rpm/setup_iojs_3.x
+++ b/rpm/setup_iojs_3.x
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X,  centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 

--- a/rpm/setup_lts.x
+++ b/rpm/setup_lts.x
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X,  centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 

--- a/rpm/src/_setup.sh
+++ b/rpm/src/_setup.sh
@@ -224,9 +224,9 @@ if [[ $DISTRO_PKG =~ ^system-release ]]; then
 
 else
 
-  ## Using the redhat-release-server-X, centos-release-X, etc. pattern
+  ## Using the redhat-release-server-X, centos-release-X,  centos-stream-release-X, etc. pattern
   ## extract the major version number of the distro
-  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\2/')
+  DIST_VERSION=$(echo $DISTRO_PKG | sed -r 's/^[[:alpha:]]+(-stream)?-release(-server|-workstation|-client|-common)?-([0-9]+).*$/\3/')
 
   if ! [[ $DIST_VERSION =~ ^[0-9][0-9]?$ ]]; then
 


### PR DESCRIPTION
This is to fix the version check for CentOS Stream. Currently the version string is as follows,

centos-stream-release-8.3-1.el8.noarch

This requires a tweak to the regex to expect -stream before -release but only optionally. Added an optional group and changed the group returned to 3.