### PR TITLE
Map kali-rolling to Debian bullseye

### DIFF
--- a/deb/setup
+++ b/deb/setup
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_0.10
+++ b/deb/setup_0.10
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_0.12
+++ b/deb/setup_0.12
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_10.x
+++ b/deb/setup_10.x
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_11.x
+++ b/deb/setup_11.x
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_12.x
+++ b/deb/setup_12.x
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_13.x
+++ b/deb/setup_13.x
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_14.x
+++ b/deb/setup_14.x
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_15.x
+++ b/deb/setup_15.x
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_4.x
+++ b/deb/setup_4.x
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_5.x
+++ b/deb/setup_5.x
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_6.x
+++ b/deb/setup_6.x
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_7.x
+++ b/deb/setup_7.x
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_8.x
+++ b/deb/setup_8.x
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_9.x
+++ b/deb/setup_9.x
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_current.x
+++ b/deb/setup_current.x
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_dev
+++ b/deb/setup_dev
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_iojs_1.x
+++ b/deb/setup_iojs_1.x
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_iojs_2.x
+++ b/deb/setup_iojs_2.x
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_iojs_3.x
+++ b/deb/setup_iojs_3.x
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/setup_lts.x
+++ b/deb/setup_lts.x
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"

--- a/deb/src/_setup.sh
+++ b/deb/src/_setup.sh
@@ -221,7 +221,7 @@ check_alt() {
 
 check_alt "SolydXK"       "solydxk-9" "Debian" "stretch"
 check_alt "Kali"          "sana"     "Debian" "jessie"
-check_alt "Kali"          "kali-rolling" "Debian" "jessie"
+check_alt "Kali"          "kali-rolling" "Debian" "bullseye"
 check_alt "Sparky Linux"  "Tyche"    "Debian" "stretch"
 check_alt "Sparky Linux"  "Nibiru"   "Debian" "buster"
 check_alt "MX Linux 17"   "Horizon"  "Debian" "stretch"


### PR DESCRIPTION
According to [the documentation of Kali](https://www.kali.org/docs/policy/kali-linux-relationship-with-debian/), Kali Linux is based on Debian testing, which is currently `bullseye`. Hence, this PR will change the mapping of kali-rolling to Debian `bullseye` instead of `jessie`.
Currently, the mapping to `jessie` is causing issues with dependency resolution on attempts to install `nodejs`. Changing the entries in `/etc/apt/sources.list.d/nodesource.list` from `jessie` to `bullseye` resolves those issues, at least for me, and it makes sense to me to map Kali to the version of Debian it is based on.

Closes #1133