### PR TITLE
Prefer 'command' over 'which' for RPM distro scripts

### DIFF
--- a/rpm/setup
+++ b/rpm/setup
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/setup_0.10
+++ b/rpm/setup_0.10
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/setup_0.12
+++ b/rpm/setup_0.12
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/setup_10.x
+++ b/rpm/setup_10.x
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/setup_11.x
+++ b/rpm/setup_11.x
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/setup_12.x
+++ b/rpm/setup_12.x
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/setup_13.x
+++ b/rpm/setup_13.x
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/setup_14.x
+++ b/rpm/setup_14.x
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/setup_15.x
+++ b/rpm/setup_15.x
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/setup_4.x
+++ b/rpm/setup_4.x
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/setup_5.x
+++ b/rpm/setup_5.x
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/setup_6.x
+++ b/rpm/setup_6.x
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/setup_7.x
+++ b/rpm/setup_7.x
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/setup_8.x
+++ b/rpm/setup_8.x
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/setup_9.x
+++ b/rpm/setup_9.x
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/setup_current.x
+++ b/rpm/setup_current.x
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/setup_iojs_1.x
+++ b/rpm/setup_iojs_1.x
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/setup_iojs_2.x
+++ b/rpm/setup_iojs_2.x
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/setup_iojs_3.x
+++ b/rpm/setup_iojs_3.x
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/setup_lts.x
+++ b/rpm/setup_lts.x
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"

--- a/rpm/src/_setup.sh
+++ b/rpm/src/_setup.sh
@@ -32,7 +32,7 @@ print_status() {
 }
 
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
+    ncolors=$(command -v tput > /dev/null && tput colors) # supports color
     if test -n "$ncolors" && test $ncolors -ge 8; then
         termcols=$(tput cols)
         bold="$(tput bold)"


### PR DESCRIPTION
'which' is not available at _all_ by default on Centos7
or Centos8 Docker images out of the box.

'command' is, and serves the same purpose in this case.

Example:

    $ docker container run -it --rm centos:7
    [root@a7ba6b6aca53 /]# command -v which
    [root@a7ba6b6aca53 /]# command -v command
    command
    [root@a7ba6b6aca53 /]# exit
    exit

    $ docker container run -it --rm centos:8
    [root@eca6d461750b /]# command -v which
    [root@eca6d461750b /]# command -v command
    command
    [root@eca6d461750b /]# exit
    exit