### PR TITLE
Add support for Rocky Linux 8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ NodeSource will continue to maintain the following architectures and may add add
 
 * **AlmaLinux 8** (64-bit)
 
+**Supported Rocky Linux OS versions:**
+
+* **Rocky 8** (64-bit)
+
 **Supported CloudLinux versions:**
 * **CloudLinux 6** (32-bit for Node <= 10.x and 64-bit)
 

--- a/rpm/setup
+++ b/rpm/setup
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_0.10
+++ b/rpm/setup_0.10
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_0.12
+++ b/rpm/setup_0.12
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_10.x
+++ b/rpm/setup_10.x
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_11.x
+++ b/rpm/setup_11.x
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_12.x
+++ b/rpm/setup_12.x
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_13.x
+++ b/rpm/setup_13.x
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_14.x
+++ b/rpm/setup_14.x
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_15.x
+++ b/rpm/setup_15.x
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_16.x
+++ b/rpm/setup_16.x
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_4.x
+++ b/rpm/setup_4.x
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_5.x
+++ b/rpm/setup_5.x
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_6.x
+++ b/rpm/setup_6.x
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_7.x
+++ b/rpm/setup_7.x
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_8.x
+++ b/rpm/setup_8.x
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_9.x
+++ b/rpm/setup_9.x
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_current.x
+++ b/rpm/setup_current.x
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_iojs_1.x
+++ b/rpm/setup_iojs_1.x
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_iojs_2.x
+++ b/rpm/setup_iojs_2.x
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_iojs_3.x
+++ b/rpm/setup_iojs_3.x
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/setup_lts.x
+++ b/rpm/setup_lts.x
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el

--- a/rpm/src/_setup.sh
+++ b/rpm/src/_setup.sh
@@ -202,7 +202,7 @@ incorrect or would like your architecture to be considered for support. \
 
 fi
 
-if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|cloudlinux|sl)- ]]; then
+if [[ $DISTRO_PKG =~ ^(redhat|centos|almalinux|rocky|cloudlinux|sl)- ]]; then
     DIST_TYPE=el
 elif [[ $DISTRO_PKG =~ ^(enterprise|system)-release- ]]; then # Oracle Linux & Amazon Linux
     DIST_TYPE=el


### PR DESCRIPTION
Rocky 8 is another rebuild of RHEL8, similar to AlmaLinux.
Trivial change in regexp.

Fixes #1228