### PR TITLE
Fix mktemp error handling

### DIFF
--- a/rpm/src/_setup.sh
+++ b/rpm/src/_setup.sh
@@ -336,7 +336,7 @@ print_status "Downloading release setup RPM..."
 ## Download to a tmp file then install it directly with `rpm`.
 ## We don't rely on RPM's ability to fetch from HTTPS directly
 echo "+ mktemp"
-RPM_TMP=$(mktemp || bail)
+RPM_TMP=$(mktemp) || bail
 
 exec_cmd "curl -sL -o '${RPM_TMP}' '${RELEASE_URL}'"
 


### PR DESCRIPTION
`bail`ing inside the subshell prevents its `exit` from exiting the toplevel script.