### PR TITLE
Support for Node v18

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,18 @@ NodeSource will maintain support for stable, testing and unstable releases of De
 <a name="debinstall"></a>
 ### Installation instructions
 
+**Node.js v18.x**:
+
+```sh
+# Using Ubuntu
+curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+sudo apt-get install -y nodejs
+
+# Using Debian, as root
+curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
+apt-get install -y nodejs
+```
+
 **Node.js v17.x**:
 
 ```sh
@@ -195,7 +207,7 @@ curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
 apt-get install -y nodejs
 ```
 
-**Node.js Current (v17.x)**:
+**Node.js Current (v18.x)**:
 
 ```sh
 # Using Ubuntu

--- a/rpm/setup
+++ b/rpm/setup
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_0.10
+++ b/rpm/setup_0.10
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_0.12
+++ b/rpm/setup_0.12
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_10.x
+++ b/rpm/setup_10.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_11.x
+++ b/rpm/setup_11.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_12.x
+++ b/rpm/setup_12.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_13.x
+++ b/rpm/setup_13.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_14.x
+++ b/rpm/setup_14.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_15.x
+++ b/rpm/setup_15.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_16.x
+++ b/rpm/setup_16.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_17.x
+++ b/rpm/setup_17.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_18.x
+++ b/rpm/setup_18.x
@@ -8,9 +8,9 @@
 #
 # Run as root or insert `sudo -E` before `bash`:
 #
-# curl -sL https://rpm.nodesource.com/setup_current.x | bash -
+# curl -sL https://rpm.nodesource.com/setup_18.x | bash -
 #   or
-# wget -qO- https://rpm.nodesource.com/setup_current.x | bash -
+# wget -qO- https://rpm.nodesource.com/setup_18.x | bash -
 #
 # CONTRIBUTIONS TO THIS SCRIPT
 #
@@ -19,7 +19,7 @@
 # please don't submit pull requests against the built scripts.
 #
 
-SCRSUFFIX="_current.x"
+SCRSUFFIX="_18.x"
 NODENAME="Node.js 18.x"
 NODEREPO="pub_18.x"
 NODEPKG="nodejs"

--- a/rpm/setup_18.x
+++ b/rpm/setup_18.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_4.x
+++ b/rpm/setup_4.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_5.x
+++ b/rpm/setup_5.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_6.x
+++ b/rpm/setup_6.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_7.x
+++ b/rpm/setup_7.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_8.x
+++ b/rpm/setup_8.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_9.x
+++ b/rpm/setup_9.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_current.x
+++ b/rpm/setup_current.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_iojs_1.x
+++ b/rpm/setup_iojs_1.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_iojs_2.x
+++ b/rpm/setup_iojs_2.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_iojs_3.x
+++ b/rpm/setup_iojs_3.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/setup_lts.x
+++ b/rpm/setup_lts.x
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/src/_setup.sh
+++ b/rpm/src/_setup.sh
@@ -110,7 +110,7 @@ ${bold}${NODENAME} is no longer actively supported!${normal}
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.
@@ -140,7 +140,7 @@ This script, located at ${bold}https://rpm.nodesource.com/setup${normal}, used t
    * ${green}https://rpm.nodesource.com/setup_12.x - Node.js v12 LTS \"Erbium\"${normal}
    * ${green}https://rpm.nodesource.com/setup_14.x - Node.js v14 LTS \"Fermium\"${normal} (recommended)
    * ${green}https://rpm.nodesource.com/setup_16.x - Node.js v16 \"Gallium\"${normal}
-   * ${green}https://rpm.nodesource.com/setup_17.x - Node.js v17 \"Seventeen\"${normal} (current)
+   * ${green}https://rpm.nodesource.com/setup_18.x - Node.js v18 \"Eighteen\"${normal} (current)
 
   Please see ${bold}https://github.com/nodejs/Release${normal} for details about which
   version may be appropriate for you.

--- a/rpm/src/build.sh
+++ b/rpm/src/build.sh
@@ -20,8 +20,9 @@ RELEASES=( "pub_0.10::nodejs:Node.js 0.10"
            "pub_15.x:_15.x:nodejs:Node.js 15.x"
            "pub_16.x:_16.x:nodejs:Node.js 16.x"
            "pub_17.x:_17.x:nodejs:Node.js 17.x"
+           "pub_18.x:_18.x:nodejs:Node.js 18.x"
            "pub_16.x:_lts.x:nodejs:Node.js 16.x"
-           "pub_17.x:_current.x:nodejs:Node.js 17.x"
+           "pub_18.x:_current.x:nodejs:Node.js 18.x"
          )
 SOURCE=_setup.sh
 DEST=../setup


### PR DESCRIPTION
closes https://github.com/nodesource/distributions/issues/1372

The `/rpm/src` scripts were updated, so that v18 is present & considered current. `build.sh` was then used to auto-generate the setup files.