### PR TITLE
Added arch to amd64 to avoid apt alerts error

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg 
 
 ```sh
 NODE_MAJOR=20
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 ```
 
 > ***Optional***: ``NODE_MAJOR`` can be changed depending on the version you need.


### PR DESCRIPTION
This will avoid errors like:

N: Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'https://deb.nodesource.com/node_20.x nodistro InRelease' doesn't support architecture 'i386'
