### PR TITLE
Update GPG key in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ NodeSource will continue to maintain the following architectures and may add add
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl gnupg
 sudo mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 ```
 
 2. Create deb repository


### PR DESCRIPTION
The GPG key URL listed in the README doesn't match what's in the repository.

# Using `nodesource-repo.gpg.key`

```
# curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key |  gpg --dearmor -o /etc/apt/trusted.gpg.d/nodesource.gpg 
# apt-add-repository --uri https://deb.nodesource.com/node_20.x --yes
Repository: 'deb https://deb.nodesource.com/node_20.x lunar main'
Description:
Archive for codename: lunar components: main
More info: https://deb.nodesource.com/node_20.x
Adding repository.
Found existing deb entry in /etc/apt/sources.list.d/archive_uri-https_deb_nodesource_com_node_20_x-lunar.list
Adding deb entry to /etc/apt/sources.list.d/archive_uri-https_deb_nodesource_com_node_20_x-lunar.list
Found existing deb-src entry in /etc/apt/sources.list.d/archive_uri-https_deb_nodesource_com_node_20_x-lunar.list
Adding disabled deb-src entry to /etc/apt/sources.list.d/archive_uri-https_deb_nodesource_com_node_20_x-lunar.list
Hit:1 https://deb.nodesource.com/node_20.x lunar InRelease
Err:1 https://deb.nodesource.com/node_20.x lunar InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 1655A0AB68576280
Hit:2 http://ports.ubuntu.com/ubuntu-ports lunar InRelease
Hit:3 http://ports.ubuntu.com/ubuntu-ports lunar-updates InRelease
Hit:4 http://ports.ubuntu.com/ubuntu-ports lunar-backports InRelease
Hit:5 http://ports.ubuntu.com/ubuntu-ports lunar-security InRelease
Reading package lists... Done
W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: https://deb.nodesource.com/node_20.x lunar InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 1655A0AB68576280
W: Failed to fetch https://deb.nodesource.com/node_20.x/dists/lunar/InRelease  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 1655A0AB68576280
W: Some index files failed to download. They have been ignored, or old ones used instead.
```

# Using `nodesource.gpg.key`

```
# curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key |  gpg --dearmor -o /etc/apt/trusted.gpg.d/nodesource.gpg 
# apt-add-repository --uri https://deb.nodesource.com/node_20.x --yes
Repository: 'deb https://deb.nodesource.com/node_20.x lunar main'
Description:
Archive for codename: lunar components: main
More info: https://deb.nodesource.com/node_20.x
Adding repository.
Found existing deb entry in /etc/apt/sources.list.d/archive_uri-https_deb_nodesource_com_node_20_x-lunar.list
Adding deb entry to /etc/apt/sources.list.d/archive_uri-https_deb_nodesource_com_node_20_x-lunar.list
Found existing deb-src entry in /etc/apt/sources.list.d/archive_uri-https_deb_nodesource_com_node_20_x-lunar.list
Adding disabled deb-src entry to /etc/apt/sources.list.d/archive_uri-https_deb_nodesource_com_node_20_x-lunar.list
Hit:1 https://deb.nodesource.com/node_20.x lunar InRelease
Hit:2 http://ports.ubuntu.com/ubuntu-ports lunar InRelease
Hit:3 http://ports.ubuntu.com/ubuntu-ports lunar-updates InRelease
Hit:4 http://ports.ubuntu.com/ubuntu-ports lunar-backports InRelease
Hit:5 http://ports.ubuntu.com/ubuntu-ports lunar-security InRelease
Reading package lists... Done
W: Skipping acquire of configured file 'nodistro/binary-arm64/Packages' as repository 'https://deb.nodesource.com/node_20.x lunar InRelease' doesn't have the component 'nodistro' (component misspelt in sources.list?)
```