### PR TITLE
apt-transport-https is required for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ NodeSource will continue to maintain the following architectures and may add add
 
 ```sh
 sudo apt-get update
-sudo apt-get install -y ca-certificates curl gnupg
+sudo apt-get install -y apt-transport-https ca-certificates curl gnupg
 sudo mkdir -p /etc/apt/keyrings
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 ```


### PR DESCRIPTION
Without it I was getting an error

```
E: The method driver /usr/lib/apt/methods/https could not be found.
E: Failed to fetch https://deb.nodesource.com/node_16.x/dists/nodistro/InRelease
E: Some index files failed to download. They have been ignored, or old ones used instead.
```