### PR TITLE
Combine multiple "copy-paste" instructions into one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,37 +80,56 @@ NodeSource will continue to maintain the following architectures and may add add
 
 > _If you have root access, you can omit the 'sudo' command as you already have full administrative privileges._
 
-1. Download and import the Nodesource GPG key
+***Optional***: ``NODE_MAJOR`` can be changed depending on the version you need.
 
+#### **Node.js v21.x**
 ```sh
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl gnupg
 sudo mkdir -p /etc/apt/keyrings
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-```
-
-2. Create deb repository
-
-```sh
-NODE_MAJOR=20
+NODE_MAJOR=21
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-```
-
-> ***Optional***: ``NODE_MAJOR`` can be changed depending on the version you need.
->
-> ```sh
-> NODE_MAJOR=16
-> NODE_MAJOR=18
-> NODE_MAJOR=20
-> NODE_MAJOR=21
-> ```
-
-3. Run Update and Install
-
-```sh
 sudo apt-get update
 sudo apt-get install nodejs -y
 ```
+
+#### **Node.js v20.x**
+```sh
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+NODE_MAJOR=20
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+sudo apt-get update
+sudo apt-get install nodejs -y
+```
+
+#### **Node.js v18.x**
+```sh
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+NODE_MAJOR=18
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+sudo apt-get update
+sudo apt-get install nodejs -y
+```
+
+#### **Node.js v16.x**
+```sh
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+NODE_MAJOR=16
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+sudo apt-get update
+sudo apt-get install nodejs -y
+```
+
 
 ### Uninstall `nodejs` Ubuntu & Debian packages
 


### PR DESCRIPTION
Recently the "Debian and Ubuntu" install instructions were split up into three code blocks.

This pull request makes them a single code block again.

Unless I'm missing something, it is much easier for the developer to copy and paste 1 section of code, instead of 3, and I can't think of any downsides.