### PR TITLE
Added arch=amd64 to repo file

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg 
 
 ```sh
 NODE_MAJOR=20
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 ```
 
 > ***Optional***: ``NODE_MAJOR`` can be changed depending on the version you need.


### PR DESCRIPTION
As you only supports `arch=amd64` I've added this to avoid error msg in console