### PR TITLE
Make gpg dearmor idempotent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
             apt-get update
             apt-get install -y ca-certificates curl gnupg
             apt install nodejs -y
-            curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+            curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor > /etc/apt/keyrings/nodesource.gpg
             echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
             apt-get update
             apt-get install nodejs -y      
@@ -39,7 +39,7 @@ jobs:
             apt-get update
             apt-get install -y ca-certificates curl gnupg
             apt install nodejs -y
-            curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+            curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor > /etc/apt/keyrings/nodesource.gpg
             echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
             apt-get update
             apt-get install nodejs -y      

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ NodeSource will continue to maintain the following architectures and may add add
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl gnupg
 sudo mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor > /etc/apt/keyrings/nodesource.gpg
 ```
 
 2. Create deb repository

--- a/scripts/nsolid_setup_deb.sh
+++ b/scripts/nsolid_setup_deb.sh
@@ -79,7 +79,7 @@ installPreReqs() {
     mkdir -p /usr/share/keyrings
 
     # Run 'curl' and 'gpg'
-    if ! curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg; then
+    if ! curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor > /usr/share/keyrings/nodesource.gpg; then
         handleError "$?" "Failed to download and import the NodeSource signing key"
     fi
 }


### PR DESCRIPTION
`gpg -o` is not idempotent because it will interactively ask for overwrite when the target file exists:

```
File '/etc/apt/keyrings/nodesource.gpg' exists. Overwrite? (y/N)
```

Instead, redirect stdout which will always overwrite the destination file. I think this is desireable because people may want to run this installation multiple times.