### PR TITLE
feat: Added support for using microdnf

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         version: [18, 20, 21]
-        os: ["fedora:36", "amazonlinux:2023"]
+        os: ["fedora:36", "amazonlinux:2023", "rockylinux:9", "redhat/ubi9:latest"]
     container:
       image: ${{ matrix.os }}
     defaults:
@@ -70,6 +70,43 @@ jobs:
       - name: Install Nodejs
         run: |
           dnf install nodejs -y
+
+      - name: Validate Node Version
+        run: |
+          node -e "console.log(process.version)"
+          NODE_VERSION=$(node -e "console.log((process.version).split('.')[0])")
+          if [[ ${NODE_VERSION} != "v${{ matrix.version }}" ]]; then
+            echo "Node version is not ${{ matrix.version }}. It is $NODE_VERSION"
+            exit 1
+          fi
+
+  rpm-minimal:
+    name: "NodeJS ${{ matrix.version }}(${{ matrix.os }})"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [18, 20, 21]
+        os: ["rockylinux:9-minimal", "redhat/ubi9-minimal:latest"]
+    container:
+      image: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: install git
+        run: |
+          microdnf update -y
+          microdnf install git -y
+
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Run Istallation Script
+        run: ./scripts/rpm/setup_${{ matrix.version }}.x
+
+      - name: Install Nodejs
+        run: |
+          microdnf install nodejs -y
 
       - name: Validate Node Version
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -193,11 +193,12 @@ NodeSource will continue to maintain the following architectures and may add add
 
 #### **Redhat versions**
 
-| Distro Name | Node 18x | Node 20x | Node 21x |
-| :---------- | :------: | :------: | :------: |
-| Redhat 7    |    ❌    |    ❌    |    ❌    |
-| Redhat 8    |    ✅    |    ✅    |    ✅    |
-| Redhat 9    |    ✅    |    ✅    |    ✅    |
+| Distro Name      | Node 18x | Node 20x | Node 21x |
+|:-----------------| :------: | :------: | :------: |
+| Redhat 7         |    ❌    |    ❌    |    ❌    |
+| Redhat 8         |    ✅    |    ✅    |    ✅    |
+| Redhat 9         |    ✅    |    ✅    |    ✅    |
+| Redhat 9-minimal |    ✅    |    ✅    |    ✅    |
 
 #### **Amazon Linux versions**
 

--- a/scripts/rpm/script_generator/README.md
+++ b/scripts/rpm/script_generator/README.md
@@ -24,8 +24,8 @@ Each script in this repository performs the following steps:
 
 1. Checks if the system is an RPM-based Linux distribution.
 2. Configures the NodeSource Node.js RPM repository for the specified version of Node.js.
-3. Checks if `dnf` or `yum` is available and updates the system using the available package manager.
-4. Logs a message indicating that the repository is configured and updated, and instructs the user to run `dnf install nodejs -y` or `yum install nodejs -y` to complete the installation.
+3. Checks if `dnf`, `yum` or `microdnf` is available and updates the system using the available package manager.
+4. Logs a message indicating that the repository is configured and updated, and instructs the user to run `dnf install nodejs -y`, `yum install nodejs -y` or `microdnf install nodejs -y` to complete the installation.
 
 The `setup_current` and `setup_latest` scripts are special scripts that install the current and latest versions of Node.js, respectively. The current version is 20.x and the latest version is 21.x.
 

--- a/scripts/rpm/script_generator/base_script.sh
+++ b/scripts/rpm/script_generator/base_script.sh
@@ -82,7 +82,7 @@ if [[ "$NODE_VERSION" == "18.x" ]] || [[ "$NODE_VERSION" == "20.x" ]]; then
   log "Added N|Solid repository for LTS version: $NODE_VERSION" "info"
 fi
 
-# Check for availability of dnf or yum
+# Check for availability of dnf, yum or microdnf
 if command_exists dnf; then
     log "dnf available, updating..." "info"
     dnf makecache --disablerepo="*" --enablerepo="nodesource-nodejs" --enablerepo="nodesource-nsolid"
@@ -92,6 +92,10 @@ elif command_exists yum; then
     log "yum available, updating..." "info"
     yum makecache --disablerepo="*" --enablerepo="nodesource-nodejs" --enablerepo="nodesource-nsolid"
     log "Repository is configured and updated. Run 'yum install nodejs -y' to complete the installation." "info"
+elif command_exists microdnf; then
+    log "microdnf available, updating..." "info"
+    microdnf makecache --disablerepo="*" --enablerepo="nodesource-nodejs" --enablerepo="nodesource-nsolid"
+    log "Repository is configured and updated. Run 'microdnf install nodejs -y' to complete the installation." "info"
 else
-    handle_error 1 "Neither yum nor dnf package manager was found. Please update your system using your package manager."
+    handle_error 1 "Neither yum, dnf nor microdnf package manager was found. Please update your system using your package manager."
 fi

--- a/scripts/rpm/setup_18.x
+++ b/scripts/rpm/setup_18.x
@@ -92,6 +92,10 @@ elif command_exists yum; then
     log "yum available, updating..." "info"
     yum makecache --disablerepo="*" --enablerepo="nodesource-nodejs" --enablerepo="nodesource-nsolid"
     log "Repository is configured and updated. Run 'yum install nodejs -y' to complete the installation." "info"
+elif command_exists microdnf; then
+    log "microdnf available, updating..." "info"
+    microdnf makecache --disablerepo="*" --enablerepo="nodesource-nodejs" --enablerepo="nodesource-nsolid"
+    log "Repository is configured and updated. Run 'microdnf install nodejs -y' to complete the installation." "info"
 else
-    handle_error 1 "Neither yum nor dnf package manager was found. Please update your system using your package manager."
+    handle_error 1 "Neither yum, dnf nor microdnf package manager was found. Please update your system using your package manager."
 fi

--- a/scripts/rpm/setup_20.x
+++ b/scripts/rpm/setup_20.x
@@ -92,6 +92,10 @@ elif command_exists yum; then
     log "yum available, updating..." "info"
     yum makecache --disablerepo="*" --enablerepo="nodesource-nodejs" --enablerepo="nodesource-nsolid"
     log "Repository is configured and updated. Run 'yum install nodejs -y' to complete the installation." "info"
+elif command_exists microdnf; then
+    log "microdnf available, updating..." "info"
+    microdnf makecache --disablerepo="*" --enablerepo="nodesource-nodejs" --enablerepo="nodesource-nsolid"
+    log "Repository is configured and updated. Run 'microdnf install nodejs -y' to complete the installation." "info"
 else
-    handle_error 1 "Neither yum nor dnf package manager was found. Please update your system using your package manager."
+    handle_error 1 "Neither yum, dnf nor microdnf package manager was found. Please update your system using your package manager."
 fi

--- a/scripts/rpm/setup_21.x
+++ b/scripts/rpm/setup_21.x
@@ -92,6 +92,10 @@ elif command_exists yum; then
     log "yum available, updating..." "info"
     yum makecache --disablerepo="*" --enablerepo="nodesource-nodejs" --enablerepo="nodesource-nsolid"
     log "Repository is configured and updated. Run 'yum install nodejs -y' to complete the installation." "info"
+elif command_exists microdnf; then
+    log "microdnf available, updating..." "info"
+    microdnf makecache --disablerepo="*" --enablerepo="nodesource-nodejs" --enablerepo="nodesource-nsolid"
+    log "Repository is configured and updated. Run 'microdnf install nodejs -y' to complete the installation." "info"
 else
-    handle_error 1 "Neither yum nor dnf package manager was found. Please update your system using your package manager."
+    handle_error 1 "Neither yum, dnf nor microdnf package manager was found. Please update your system using your package manager."
 fi

--- a/scripts/rpm/setup_current.x
+++ b/scripts/rpm/setup_current.x
@@ -92,6 +92,10 @@ elif command_exists yum; then
     log "yum available, updating..." "info"
     yum makecache --disablerepo="*" --enablerepo="nodesource-nodejs" --enablerepo="nodesource-nsolid"
     log "Repository is configured and updated. Run 'yum install nodejs -y' to complete the installation." "info"
+elif command_exists microdnf; then
+    log "microdnf available, updating..." "info"
+    microdnf makecache --disablerepo="*" --enablerepo="nodesource-nodejs" --enablerepo="nodesource-nsolid"
+    log "Repository is configured and updated. Run 'microdnf install nodejs -y' to complete the installation." "info"
 else
-    handle_error 1 "Neither yum nor dnf package manager was found. Please update your system using your package manager."
+    handle_error 1 "Neither yum, dnf nor microdnf package manager was found. Please update your system using your package manager."
 fi

--- a/scripts/rpm/setup_lts.x
+++ b/scripts/rpm/setup_lts.x
@@ -92,6 +92,10 @@ elif command_exists yum; then
     log "yum available, updating..." "info"
     yum makecache --disablerepo="*" --enablerepo="nodesource-nodejs" --enablerepo="nodesource-nsolid"
     log "Repository is configured and updated. Run 'yum install nodejs -y' to complete the installation." "info"
+elif command_exists microdnf; then
+    log "microdnf available, updating..." "info"
+    microdnf makecache --disablerepo="*" --enablerepo="nodesource-nodejs" --enablerepo="nodesource-nsolid"
+    log "Repository is configured and updated. Run 'microdnf install nodejs -y' to complete the installation." "info"
 else
-    handle_error 1 "Neither yum nor dnf package manager was found. Please update your system using your package manager."
+    handle_error 1 "Neither yum, dnf nor microdnf package manager was found. Please update your system using your package manager."
 fi


### PR DESCRIPTION
Tested with [rockylinux:9-minimal](https://hub.docker.com/_/rockylinux) and [redhat/ubi9-minimal](https://hub.docker.com/r/redhat/ubi9-minimal/tags) container images which both only contain [`microdnf`](https://github.com/rpm-software-management/microdnf) instead of `dnf` (or `yum`).