### PR TITLE
chore: Bump LTS to 22.x

### DIFF
--- a/scripts/deb/setup_lts.x
+++ b/scripts/deb/setup_lts.x
@@ -103,7 +103,7 @@ configure_repo() {
 }
 
 # Define Node.js version
-NODE_VERSION="20.x"
+NODE_VERSION="22.x"
 
 # Check OS
 check_os

--- a/scripts/rpm/setup_lts.x
+++ b/scripts/rpm/setup_lts.x
@@ -41,7 +41,7 @@ rm -f /etc/yum.repos.d/nodesource*.repo
 log "Old repositories removed" "info"
 
 # Define Node.js version
-NODE_VERSION="20.x"
+NODE_VERSION="22.x"
 
 # Get system architecture
 SYS_ARCH=$(uname -m)


### PR DESCRIPTION
LTS has been updated to v22.11.0
https://nodejs.org/en/blog/release/v22.11.0