### PR TITLE
feat: set node 24 as LTS and node 25 as current

### DIFF
--- a/scripts/deb/script_generator/generator.sh
+++ b/scripts/deb/script_generator/generator.sh
@@ -33,8 +33,8 @@ for version in "${versions[@]}"; do
 done
 
 # Define LTS and current Node.js versions
-lts_version="22"
-current_version="24"
+lts_version="24"
+current_version="25"
 
 # Create setup_lts and setup_current scripts
 create_script "$lts_version" "lts"

--- a/scripts/deb/setup_lts.x
+++ b/scripts/deb/setup_lts.x
@@ -103,7 +103,7 @@ configure_repo() {
 }
 
 # Define Node.js version
-NODE_VERSION="22.x"
+NODE_VERSION="24.x"
 
 # Check OS
 check_os

--- a/scripts/rpm/script_generator/generator.sh
+++ b/scripts/rpm/script_generator/generator.sh
@@ -33,8 +33,8 @@ for version in "${versions[@]}"; do
 done
 
 # Define LTS and current Node.js versions
-lts_version="22"
-current_version="24"
+lts_version="24"
+current_version="25"
 
 # Create setup_lts and setup_current scripts
 create_script "$lts_version" "lts"

--- a/scripts/rpm/setup_lts.x
+++ b/scripts/rpm/setup_lts.x
@@ -41,7 +41,7 @@ rm -f /etc/yum.repos.d/nodesource*.repo
 log "Old repositories removed" "info"
 
 # Define Node.js version
-NODE_VERSION="22.x"
+NODE_VERSION="24.x"
 
 # Get system architecture
 SYS_ARCH=$(uname -m)


### PR DESCRIPTION
Node 24 is LTS since 2025-10-28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js version targets in installation and setup scripts for both Debian and RPM-based systems. LTS designation now points to Node.js version 24 (previously 22) while the current version advances to 25 (previously 24). These updates will directly affect the default Node.js versions installed when running system setup scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->