### PR TITLE
CI: add NSOLID to the CI tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,44 @@ jobs:
           exit 1
          fi
 
+  nsolid-deb:
+    name: "NSolid ${{ matrix.version }}(${{ matrix.os }})"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [ 18, 20, 22, 24 ]
+        os: [ "ubuntu:24.04", "ubuntu:22.04", "debian:10" ]
+    container:
+      image: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Fix sources.list for Debian 10
+        if: contains(matrix.os, 'debian:10')
+        run: |
+          echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.list
+          apt-get -o Acquire::Check-Valid-Until=false -o Acquire::AllowInsecureRepositories=true update
+
+      - name: Run Installation Script
+        run: ./scripts/deb/setup_${{ matrix.version }}.x
+
+      - name: Install NSolid
+        run: apt install nsolid -y
+
+      - name: Validate NSolid Version
+        run: |
+         nsolid -e "console.log(process.version)"
+         NSOLID_VERSION=$(nsolid -e "console.log(process.version.split('.')[0])")
+        
+         if [[ ${NSOLID_VERSION} != "v${{ matrix.version }}" ]]; then
+          echo "NSolid version is not ${{ matrix.version }}. It is $NSOLID_VERSION"
+          exit 1
+         fi
+
   rpm:
     name: "NodeJS ${{ matrix.version }}(${{ matrix.os }})"
     runs-on: ubuntu-latest
@@ -104,6 +142,61 @@ jobs:
             exit 1
           fi
 
+  nsolid-rpm:
+    name: "NSolid ${{ matrix.version }}(${{ matrix.os }})"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [ 18, 20, 22, 24 ]
+        os: [ "fedora:36", "amazonlinux:2023", "rockylinux:9", "redhat/ubi9:latest" ]
+    container:
+      image: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Patch Rocky repos (avoid broken mirror)
+        if: contains(matrix.os, 'rocky')
+        run: |
+          set -euxo pipefail
+          for f in /etc/yum.repos.d/Rocky-*.repo; do
+            [ -f "$f" ] || continue
+            sed -i 's|^baseurl=.*|# baseurl disabled by CI|' "$f" || true
+            if grep -q '^mirrorlist=' "$f"; then
+              sed -i 's|^mirrorlist=.*|mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=$repo&release=$releasever|g' "$f" || true
+            else
+              echo 'mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=$repo&release=$releasever' >> "$f" || true
+            fi
+            if ! grep -qi '^skip_if_unavailable=' "$f"; then
+              echo 'skip_if_unavailable=True' >> "$f"
+            fi
+          done
+          (dnf clean all || microdnf clean all || true)
+          (dnf -y makecache || microdnf -y makecache || true)
+      - name: install git
+        run: |
+          dnf update -y
+          dnf install git -y
+
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Run Installation Script
+        run: ./scripts/rpm/setup_${{ matrix.version }}.x
+
+      - name: Install NSolid
+        run: |
+          dnf install nsolid -y
+
+      - name: Validate NSolid Version
+        run: |
+          nsolid -e "console.log(process.version)"
+          NSOLID_VERSION=$(nsolid -e "console.log((process.version).split('.')[0])")
+          if [[ ${NSOLID_VERSION} != "v${{ matrix.version }}" ]]; then
+            echo "NSolid version is not ${{ matrix.version }}. It is $NSOLID_VERSION"
+            exit 1
+          fi
+
   rpm-minimal:
     name: "NodeJS ${{ matrix.version }}(${{ matrix.os }})"
     runs-on: ubuntu-latest
@@ -156,5 +249,60 @@ jobs:
           NODE_VERSION=$(node -e "console.log((process.version).split('.')[0])")
           if [[ ${NODE_VERSION} != "v${{ matrix.version }}" ]]; then
             echo "Node version is not ${{ matrix.version }}. It is $NODE_VERSION"
+            exit 1
+          fi
+
+  nsolid-rpm-minimal:
+    name: "NSolid ${{ matrix.version }}(${{ matrix.os }})"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [ 18, 20, 22, 24 ]
+        os: [ "rockylinux:9-minimal", "redhat/ubi9-minimal:latest" ]
+    container:
+      image: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Patch Rocky repos (avoid broken mirror)
+        if: contains(matrix.os, 'rocky')
+        run: |
+          set -euxo pipefail
+          for f in /etc/yum.repos.d/Rocky-*.repo; do
+            [ -f "$f" ] || continue
+            sed -i 's|^baseurl=.*|# baseurl disabled by CI|' "$f" || true
+            if grep -q '^mirrorlist=' "$f"; then
+              sed -i 's|^mirrorlist=.*|mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=$repo&release=$releasever|g' "$f" || true
+            else
+              echo 'mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=$repo&release=$releasever' >> "$f" || true
+            fi
+            if ! grep -qi '^skip_if_unavailable=' "$f"; then
+              echo 'skip_if_unavailable=True' >> "$f"
+            fi
+          done
+          (dnf clean all || microdnf clean all || true)
+          (dnf -y makecache || microdnf -y makecache || true)
+      - name: install git
+        run: |
+          microdnf update -y
+          microdnf install git -y
+
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Run Installation Script
+        run: ./scripts/rpm/setup_${{ matrix.version }}.x
+
+      - name: Install NSolid
+        run: |
+          microdnf install nsolid -y
+
+      - name: Validate NSolid Version
+        run: |
+          nsolid -e "console.log(process.version)"
+          NSOLID_VERSION=$(nsolid -e "console.log((process.version).split('.')[0])")
+          if [[ ${NSOLID_VERSION} != "v${{ matrix.version }}" ]]; then
+            echo "NSolid version is not ${{ matrix.version }}. It is $NSOLID_VERSION"
             exit 1
           fi

--- a/scripts/rpm/setup_23.x
+++ b/scripts/rpm/setup_23.x
@@ -66,7 +66,7 @@ module_hotfixes=1"
 echo "$NODEJS_REPO_CONTENT" | tee /etc/yum.repos.d/nodesource-nodejs.repo > /dev/null
 
 # Check if Node.js version is an LTS version
-if [[ "$NODE_VERSION" == "20.x" ]] || [[ "$NODE_VERSION" == "22.x" ]]; then
+if [[ "$NODE_VERSION" == "20.x" ]] || [[ "$NODE_VERSION" == "22.x" ]] || [[ "$NODE_VERSION" == "24.x" ]]; then
   # Repository content for N|Solid
   NSOLID_REPO_CONTENT="[nodesource-nsolid]
 name=N|Solid Packages for Linux RPM based distros - $SYS_ARCH

--- a/scripts/rpm/setup_24.x
+++ b/scripts/rpm/setup_24.x
@@ -66,7 +66,7 @@ module_hotfixes=1"
 echo "$NODEJS_REPO_CONTENT" | tee /etc/yum.repos.d/nodesource-nodejs.repo > /dev/null
 
 # Check if Node.js version is an LTS version
-if [[ "$NODE_VERSION" == "20.x" ]] || [[ "$NODE_VERSION" == "22.x" ]]; then
+if [[ "$NODE_VERSION" == "20.x" ]] || [[ "$NODE_VERSION" == "22.x" ]] || [[ "$NODE_VERSION" == "24.x" ]]; then
   # Repository content for N|Solid
   NSOLID_REPO_CONTENT="[nodesource-nsolid]
 name=N|Solid Packages for Linux RPM based distros - $SYS_ARCH

--- a/scripts/rpm/setup_25.x
+++ b/scripts/rpm/setup_25.x
@@ -66,7 +66,7 @@ module_hotfixes=1"
 echo "$NODEJS_REPO_CONTENT" | tee /etc/yum.repos.d/nodesource-nodejs.repo > /dev/null
 
 # Check if Node.js version is an LTS version
-if [[ "$NODE_VERSION" == "20.x" ]] || [[ "$NODE_VERSION" == "22.x" ]]; then
+if [[ "$NODE_VERSION" == "20.x" ]] || [[ "$NODE_VERSION" == "22.x" ]] || [[ "$NODE_VERSION" == "24.x" ]]; then
   # Repository content for N|Solid
   NSOLID_REPO_CONTENT="[nodesource-nsolid]
 name=N|Solid Packages for Linux RPM based distros - $SYS_ARCH

--- a/scripts/rpm/setup_current.x
+++ b/scripts/rpm/setup_current.x
@@ -66,7 +66,7 @@ module_hotfixes=1"
 echo "$NODEJS_REPO_CONTENT" | tee /etc/yum.repos.d/nodesource-nodejs.repo > /dev/null
 
 # Check if Node.js version is an LTS version
-if [[ "$NODE_VERSION" == "20.x" ]] || [[ "$NODE_VERSION" == "22.x" ]]; then
+if [[ "$NODE_VERSION" == "20.x" ]] || [[ "$NODE_VERSION" == "22.x" ]] || [[ "$NODE_VERSION" == "24.x" ]]; then
   # Repository content for N|Solid
   NSOLID_REPO_CONTENT="[nodesource-nsolid]
 name=N|Solid Packages for Linux RPM based distros - $SYS_ARCH


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds support for Node.js 24.x in RPM-based installation paths, enabling the N|Solid repository and installer guidance for 24.x releases.

* **Chores**
  * Reorganized CI workflow into more granular jobs by package type and target environment for clearer, parallelized build coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->