### PR TITLE
feat: move to use deb822 .sources

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 18, 20, 22, 23, 24, 25 ]
-        os: [ "ubuntu:24.04", "ubuntu:22.04", "debian:10" ]
+        version: [ 20, 22, 24, 25 ]
+        os: [ "ubuntu:24.04", "ubuntu:22.04", "debian:13", "debian:11" ]
     container:
       image: ${{ matrix.os }}
     defaults:
@@ -27,14 +27,12 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
-      - name: Fix sources.list for Debian 10
-        if: contains(matrix.os, 'debian:10')
-        run: |
-          echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.list
-          apt-get -o Acquire::Check-Valid-Until=false -o Acquire::AllowInsecureRepositories=true update
-
       - name: Run Installation Script
         run: ./scripts/deb/setup_${{ matrix.version }}.x
+
+      - name: Audit Repository
+        if: matrix.os == 'debian:13'
+        run: apt update --audit
 
       - name: Install Nodejs
         run: apt install nodejs -y
@@ -49,35 +47,14 @@ jobs:
           exit 1
          fi
 
-  nsolid-deb:
-    name: "NSolid ${{ matrix.version }}(${{ matrix.os }})"
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: [ 18, 20, 22, 24 ]
-        os: [ "ubuntu:24.04", "ubuntu:22.04", "debian:10" ]
-    container:
-      image: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-
-      - name: Fix sources.list for Debian 10
-        if: contains(matrix.os, 'debian:10')
-        run: |
-          echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.list
-          apt-get -o Acquire::Check-Valid-Until=false -o Acquire::AllowInsecureRepositories=true update
-
-      - name: Run Installation Script
-        run: ./scripts/deb/setup_${{ matrix.version }}.x
-
       - name: Install NSolid
-        run: apt install nsolid -y
+        if: matrix.version != 25
+        run: |
+         apt remove nodejs -y
+         apt install nsolid -y
 
       - name: Validate NSolid Version
+        if: matrix.version != 25
         run: |
          nsolid -e "console.log(process.version)"
          NSOLID_VERSION=$(nsolid -e "console.log(process.version.split('.')[0])")
@@ -92,32 +69,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 18, 20, 22, 23, 24, 25 ]
-        os: [ "fedora:36", "amazonlinux:2023", "rockylinux:9", "redhat/ubi9:latest" ]
+        version: [ 20, 22, 24, 25 ]
+        os: [ "fedora:41", "amazonlinux:2023", "rockylinux:9", "rockylinux:8", "redhat/ubi9:latest" ]
     container:
       image: ${{ matrix.os }}
     defaults:
       run:
         shell: bash
     steps:
-      - name: Patch Rocky repos (avoid broken mirror)
-        if: contains(matrix.os, 'rocky')
-        run: |
-          set -euxo pipefail
-          for f in /etc/yum.repos.d/Rocky-*.repo; do
-            [ -f "$f" ] || continue
-            sed -i 's|^baseurl=.*|# baseurl disabled by CI|' "$f" || true
-            if grep -q '^mirrorlist=' "$f"; then
-              sed -i 's|^mirrorlist=.*|mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=$repo&release=$releasever|g' "$f" || true
-            else
-              echo 'mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=$repo&release=$releasever' >> "$f" || true
-            fi
-            if ! grep -qi '^skip_if_unavailable=' "$f"; then
-              echo 'skip_if_unavailable=True' >> "$f"
-            fi
-          done
-          (dnf clean all || microdnf clean all || true)
-          (dnf -y makecache || microdnf -y makecache || true)
       - name: install git
         run: |
           dnf update -y
@@ -128,6 +87,9 @@ jobs:
 
       - name: Run Istallation Script
         run: ./scripts/rpm/setup_${{ matrix.version }}.x
+
+      - name: Audit Repository
+        run: dnf repolist
 
       - name: Install Nodejs
         run: |
@@ -142,53 +104,14 @@ jobs:
             exit 1
           fi
 
-  nsolid-rpm:
-    name: "NSolid ${{ matrix.version }}(${{ matrix.os }})"
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: [ 18, 20, 22, 24 ]
-        os: [ "fedora:36", "amazonlinux:2023", "rockylinux:9", "redhat/ubi9:latest" ]
-    container:
-      image: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - name: Patch Rocky repos (avoid broken mirror)
-        if: contains(matrix.os, 'rocky')
-        run: |
-          set -euxo pipefail
-          for f in /etc/yum.repos.d/Rocky-*.repo; do
-            [ -f "$f" ] || continue
-            sed -i 's|^baseurl=.*|# baseurl disabled by CI|' "$f" || true
-            if grep -q '^mirrorlist=' "$f"; then
-              sed -i 's|^mirrorlist=.*|mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=$repo&release=$releasever|g' "$f" || true
-            else
-              echo 'mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=$repo&release=$releasever' >> "$f" || true
-            fi
-            if ! grep -qi '^skip_if_unavailable=' "$f"; then
-              echo 'skip_if_unavailable=True' >> "$f"
-            fi
-          done
-          (dnf clean all || microdnf clean all || true)
-          (dnf -y makecache || microdnf -y makecache || true)
-      - name: install git
-        run: |
-          dnf update -y
-          dnf install git -y
-
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-
-      - name: Run Installation Script
-        run: ./scripts/rpm/setup_${{ matrix.version }}.x
-
       - name: Install NSolid
+        if: matrix.version != 25
         run: |
+          dnf remove nodejs -y
           dnf install nsolid -y
 
       - name: Validate NSolid Version
+        if: matrix.version != 25
         run: |
           nsolid -e "console.log(process.version)"
           NSOLID_VERSION=$(nsolid -e "console.log((process.version).split('.')[0])")
@@ -202,32 +125,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 18, 20, 22, 23, 24, 25]
-        os: [ "rockylinux:9-minimal", "redhat/ubi9-minimal:latest" ]
+        version: [ 20, 22, 24, 25]
+        os: [ "rockylinux:9-minimal", "rockylinux:8-minimal", "redhat/ubi9-minimal:latest" ]
     container:
       image: ${{ matrix.os }}
     defaults:
       run:
         shell: bash
     steps:
-      - name: Patch Rocky repos (avoid broken mirror)
-        if: contains(matrix.os, 'rocky')
-        run: |
-          set -euxo pipefail
-          for f in /etc/yum.repos.d/Rocky-*.repo; do
-            [ -f "$f" ] || continue
-            sed -i 's|^baseurl=.*|# baseurl disabled by CI|' "$f" || true
-            if grep -q '^mirrorlist=' "$f"; then
-              sed -i 's|^mirrorlist=.*|mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=$repo&release=$releasever|g' "$f" || true
-            else
-              echo 'mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=$repo&release=$releasever' >> "$f" || true
-            fi
-            if ! grep -qi '^skip_if_unavailable=' "$f"; then
-              echo 'skip_if_unavailable=True' >> "$f"
-            fi
-          done
-          (dnf clean all || microdnf clean all || true)
-          (dnf -y makecache || microdnf -y makecache || true)
       - name: install git
         run: |
           microdnf update -y
@@ -238,6 +143,9 @@ jobs:
 
       - name: Run Istallation Script
         run: ./scripts/rpm/setup_${{ matrix.version }}.x
+
+      - name: Audit Repository
+        run: microdnf repolist
 
       - name: Install Nodejs
         run: |
@@ -252,53 +160,14 @@ jobs:
             exit 1
           fi
 
-  nsolid-rpm-minimal:
-    name: "NSolid ${{ matrix.version }}(${{ matrix.os }})"
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: [ 18, 20, 22, 24 ]
-        os: [ "rockylinux:9-minimal", "redhat/ubi9-minimal:latest" ]
-    container:
-      image: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - name: Patch Rocky repos (avoid broken mirror)
-        if: contains(matrix.os, 'rocky')
-        run: |
-          set -euxo pipefail
-          for f in /etc/yum.repos.d/Rocky-*.repo; do
-            [ -f "$f" ] || continue
-            sed -i 's|^baseurl=.*|# baseurl disabled by CI|' "$f" || true
-            if grep -q '^mirrorlist=' "$f"; then
-              sed -i 's|^mirrorlist=.*|mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=$repo&release=$releasever|g' "$f" || true
-            else
-              echo 'mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=$repo&release=$releasever' >> "$f" || true
-            fi
-            if ! grep -qi '^skip_if_unavailable=' "$f"; then
-              echo 'skip_if_unavailable=True' >> "$f"
-            fi
-          done
-          (dnf clean all || microdnf clean all || true)
-          (dnf -y makecache || microdnf -y makecache || true)
-      - name: install git
-        run: |
-          microdnf update -y
-          microdnf install git -y
-
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-
-      - name: Run Installation Script
-        run: ./scripts/rpm/setup_${{ matrix.version }}.x
-
       - name: Install NSolid
+        if: matrix.version != 25
         run: |
+          microdnf remove nodejs -y
           microdnf install nsolid -y
 
       - name: Validate NSolid Version
+        if: matrix.version != 25
         run: |
           nsolid -e "console.log(process.version)"
           NSOLID_VERSION=$(nsolid -e "console.log((process.version).split('.')[0])")

--- a/.github/workflows/deprecated.yaml
+++ b/.github/workflows/deprecated.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 16 ]
+        version: [ 16, 18 ]
         os: [ "ubuntu:20.04", "debian:10" ]
     container:
       image: ${{ matrix.os }}
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 16 ]
+        version: [ 16, 18 ]
         os: [ "fedora:29", "amazonlinux:2023" ]
     container:
       image: ${{ matrix.os }}

--- a/scripts/deb/script_generator/base_script.sh
+++ b/scripts/deb/script_generator/base_script.sh
@@ -58,6 +58,7 @@ install_pre_reqs() {
 
     rm -f /usr/share/keyrings/nodesource.gpg || true
     rm -f /etc/apt/sources.list.d/nodesource.list || true
+    rm -f /etc/apt/sources.list.d/nodesource.sources || true
 
     # Run 'curl' and 'gpg' to download and import the NodeSource signing key
     if ! curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg; then
@@ -79,7 +80,14 @@ configure_repo() {
       handle_error "1" "Unsupported architecture: $arch. Only amd64, arm64 are supported. Contact Nodesource for an extended support version https://nodesource.com/pages/contact-us.html."
     fi
 
-    echo "deb [arch=$arch signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$node_version nodistro main" | tee /etc/apt/sources.list.d/nodesource.list > /dev/null
+    cat <<EOF | tee /etc/apt/sources.list.d/nodesource.sources > /dev/null
+Types: deb
+URIs: https://deb.nodesource.com/node_$node_version
+Suites: nodistro
+Components: main
+Architectures: $arch
+Signed-By: /usr/share/keyrings/nodesource.gpg
+EOF
 
     # N|solid Config
     echo "Package: nsolid" | tee /etc/apt/preferences.d/nsolid > /dev/null

--- a/scripts/deb/script_generator/generator.sh
+++ b/scripts/deb/script_generator/generator.sh
@@ -25,7 +25,7 @@ if [ ! -f "$base_script" ]; then
 fi
 
 # List of versions
-versions=("23" "24" "25")
+versions=("20" "22" "24" "25")
 
 # Iterate over the versions and create scripts
 for version in "${versions[@]}"; do

--- a/scripts/deb/setup_20.x
+++ b/scripts/deb/setup_20.x
@@ -58,6 +58,7 @@ install_pre_reqs() {
 
     rm -f /usr/share/keyrings/nodesource.gpg || true
     rm -f /etc/apt/sources.list.d/nodesource.list || true
+    rm -f /etc/apt/sources.list.d/nodesource.sources || true
 
     # Run 'curl' and 'gpg' to download and import the NodeSource signing key
     if ! curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg; then
@@ -75,11 +76,18 @@ configure_repo() {
     local node_version=$1
 
     arch=$(dpkg --print-architecture)
-    if [ "$arch" != "amd64" ] && [ "$arch" != "arm64" ] && [ "$arch" != "armhf" ]; then
-      handle_error "1" "Unsupported architecture: $arch. Only amd64, arm64, and armhf are supported."
+    if [ "$arch" != "amd64" ] && [ "$arch" != "arm64" ]; then
+      handle_error "1" "Unsupported architecture: $arch. Only amd64, arm64 are supported. Contact Nodesource for an extended support version https://nodesource.com/pages/contact-us.html."
     fi
 
-    echo "deb [arch=$arch signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$node_version nodistro main" | tee /etc/apt/sources.list.d/nodesource.list > /dev/null
+    cat <<EOF | tee /etc/apt/sources.list.d/nodesource.sources > /dev/null
+Types: deb
+URIs: https://deb.nodesource.com/node_$node_version
+Suites: nodistro
+Components: main
+Architectures: $arch
+Signed-By: /usr/share/keyrings/nodesource.gpg
+EOF
 
     # N|solid Config
     echo "Package: nsolid" | tee /etc/apt/preferences.d/nsolid > /dev/null

--- a/scripts/deb/setup_22.x
+++ b/scripts/deb/setup_22.x
@@ -58,6 +58,7 @@ install_pre_reqs() {
 
     rm -f /usr/share/keyrings/nodesource.gpg || true
     rm -f /etc/apt/sources.list.d/nodesource.list || true
+    rm -f /etc/apt/sources.list.d/nodesource.sources || true
 
     # Run 'curl' and 'gpg' to download and import the NodeSource signing key
     if ! curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg; then
@@ -75,11 +76,18 @@ configure_repo() {
     local node_version=$1
 
     arch=$(dpkg --print-architecture)
-    if [ "$arch" != "amd64" ] && [ "$arch" != "arm64" ] && [ "$arch" != "armhf" ]; then
-      handle_error "1" "Unsupported architecture: $arch. Only amd64, arm64, and armhf are supported."
+    if [ "$arch" != "amd64" ] && [ "$arch" != "arm64" ]; then
+      handle_error "1" "Unsupported architecture: $arch. Only amd64, arm64 are supported. Contact Nodesource for an extended support version https://nodesource.com/pages/contact-us.html."
     fi
 
-    echo "deb [arch=$arch signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$node_version nodistro main" | tee /etc/apt/sources.list.d/nodesource.list > /dev/null
+    cat <<EOF | tee /etc/apt/sources.list.d/nodesource.sources > /dev/null
+Types: deb
+URIs: https://deb.nodesource.com/node_$node_version
+Suites: nodistro
+Components: main
+Architectures: $arch
+Signed-By: /usr/share/keyrings/nodesource.gpg
+EOF
 
     # N|solid Config
     echo "Package: nsolid" | tee /etc/apt/preferences.d/nsolid > /dev/null

--- a/scripts/deb/setup_23.x
+++ b/scripts/deb/setup_23.x
@@ -58,6 +58,7 @@ install_pre_reqs() {
 
     rm -f /usr/share/keyrings/nodesource.gpg || true
     rm -f /etc/apt/sources.list.d/nodesource.list || true
+    rm -f /etc/apt/sources.list.d/nodesource.sources || true
 
     # Run 'curl' and 'gpg' to download and import the NodeSource signing key
     if ! curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg; then
@@ -79,7 +80,14 @@ configure_repo() {
       handle_error "1" "Unsupported architecture: $arch. Only amd64, arm64 are supported. Contact Nodesource for an extended support version https://nodesource.com/pages/contact-us.html."
     fi
 
-    echo "deb [arch=$arch signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$node_version nodistro main" | tee /etc/apt/sources.list.d/nodesource.list > /dev/null
+    cat <<EOF | tee /etc/apt/sources.list.d/nodesource.sources > /dev/null
+Types: deb
+URIs: https://deb.nodesource.com/node_$node_version
+Suites: nodistro
+Components: main
+Architectures: $arch
+Signed-By: /usr/share/keyrings/nodesource.gpg
+EOF
 
     # N|solid Config
     echo "Package: nsolid" | tee /etc/apt/preferences.d/nsolid > /dev/null

--- a/scripts/deb/setup_24.x
+++ b/scripts/deb/setup_24.x
@@ -58,6 +58,7 @@ install_pre_reqs() {
 
     rm -f /usr/share/keyrings/nodesource.gpg || true
     rm -f /etc/apt/sources.list.d/nodesource.list || true
+    rm -f /etc/apt/sources.list.d/nodesource.sources || true
 
     # Run 'curl' and 'gpg' to download and import the NodeSource signing key
     if ! curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg; then
@@ -79,7 +80,14 @@ configure_repo() {
       handle_error "1" "Unsupported architecture: $arch. Only amd64, arm64 are supported. Contact Nodesource for an extended support version https://nodesource.com/pages/contact-us.html."
     fi
 
-    echo "deb [arch=$arch signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$node_version nodistro main" | tee /etc/apt/sources.list.d/nodesource.list > /dev/null
+    cat <<EOF | tee /etc/apt/sources.list.d/nodesource.sources > /dev/null
+Types: deb
+URIs: https://deb.nodesource.com/node_$node_version
+Suites: nodistro
+Components: main
+Architectures: $arch
+Signed-By: /usr/share/keyrings/nodesource.gpg
+EOF
 
     # N|solid Config
     echo "Package: nsolid" | tee /etc/apt/preferences.d/nsolid > /dev/null

--- a/scripts/deb/setup_25.x
+++ b/scripts/deb/setup_25.x
@@ -58,6 +58,7 @@ install_pre_reqs() {
 
     rm -f /usr/share/keyrings/nodesource.gpg || true
     rm -f /etc/apt/sources.list.d/nodesource.list || true
+    rm -f /etc/apt/sources.list.d/nodesource.sources || true
 
     # Run 'curl' and 'gpg' to download and import the NodeSource signing key
     if ! curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg; then
@@ -79,7 +80,14 @@ configure_repo() {
       handle_error "1" "Unsupported architecture: $arch. Only amd64, arm64 are supported. Contact Nodesource for an extended support version https://nodesource.com/pages/contact-us.html."
     fi
 
-    echo "deb [arch=$arch signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$node_version nodistro main" | tee /etc/apt/sources.list.d/nodesource.list > /dev/null
+    cat <<EOF | tee /etc/apt/sources.list.d/nodesource.sources > /dev/null
+Types: deb
+URIs: https://deb.nodesource.com/node_$node_version
+Suites: nodistro
+Components: main
+Architectures: $arch
+Signed-By: /usr/share/keyrings/nodesource.gpg
+EOF
 
     # N|solid Config
     echo "Package: nsolid" | tee /etc/apt/preferences.d/nsolid > /dev/null

--- a/scripts/deb/setup_current.x
+++ b/scripts/deb/setup_current.x
@@ -58,6 +58,7 @@ install_pre_reqs() {
 
     rm -f /usr/share/keyrings/nodesource.gpg || true
     rm -f /etc/apt/sources.list.d/nodesource.list || true
+    rm -f /etc/apt/sources.list.d/nodesource.sources || true
 
     # Run 'curl' and 'gpg' to download and import the NodeSource signing key
     if ! curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg; then
@@ -79,7 +80,14 @@ configure_repo() {
       handle_error "1" "Unsupported architecture: $arch. Only amd64, arm64 are supported. Contact Nodesource for an extended support version https://nodesource.com/pages/contact-us.html."
     fi
 
-    echo "deb [arch=$arch signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$node_version nodistro main" | tee /etc/apt/sources.list.d/nodesource.list > /dev/null
+    cat <<EOF | tee /etc/apt/sources.list.d/nodesource.sources > /dev/null
+Types: deb
+URIs: https://deb.nodesource.com/node_$node_version
+Suites: nodistro
+Components: main
+Architectures: $arch
+Signed-By: /usr/share/keyrings/nodesource.gpg
+EOF
 
     # N|solid Config
     echo "Package: nsolid" | tee /etc/apt/preferences.d/nsolid > /dev/null

--- a/scripts/deb/setup_lts.x
+++ b/scripts/deb/setup_lts.x
@@ -58,6 +58,7 @@ install_pre_reqs() {
 
     rm -f /usr/share/keyrings/nodesource.gpg || true
     rm -f /etc/apt/sources.list.d/nodesource.list || true
+    rm -f /etc/apt/sources.list.d/nodesource.sources || true
 
     # Run 'curl' and 'gpg' to download and import the NodeSource signing key
     if ! curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg; then
@@ -79,7 +80,14 @@ configure_repo() {
       handle_error "1" "Unsupported architecture: $arch. Only amd64, arm64 are supported. Contact Nodesource for an extended support version https://nodesource.com/pages/contact-us.html."
     fi
 
-    echo "deb [arch=$arch signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$node_version nodistro main" | tee /etc/apt/sources.list.d/nodesource.list > /dev/null
+    cat <<EOF | tee /etc/apt/sources.list.d/nodesource.sources > /dev/null
+Types: deb
+URIs: https://deb.nodesource.com/node_$node_version
+Suites: nodistro
+Components: main
+Architectures: $arch
+Signed-By: /usr/share/keyrings/nodesource.gpg
+EOF
 
     # N|solid Config
     echo "Package: nsolid" | tee /etc/apt/preferences.d/nsolid > /dev/null


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Installation scripts now generate packages for Node.js 20 and 22 (in addition to 24, 25). Debian installers now write structured repository sources, remove legacy entries during cleanup, enforce keyring permissions with clearer error messages, and drop armhf (32-bit ARM) support for affected installers.

* **Chores**
  * CI workflows updated: revised distro/matrix targets, added repository-audit steps, and adjusted conditional NSolid installation/validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->