### PR TITLE
Added support for TencentOS and OpenCloudOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         version: [ 20, 22, 24, 25 ]
-        os: [ "fedora:41", "amazonlinux:2023", "rockylinux:9", "rockylinux:8", "redhat/ubi9:latest" ]
+        os: [ "fedora:41", "amazonlinux:2023", "rockylinux:9", "rockylinux:8", "redhat/ubi9:latest", "tencentos/tencentos4:latest" ]
     container:
       image: ${{ matrix.os }}
     defaults:
@@ -126,7 +126,7 @@ jobs:
     strategy:
       matrix:
         version: [ 20, 22, 24, 25]
-        os: [ "rockylinux:9-minimal", "rockylinux:8-minimal", "redhat/ubi9-minimal:latest" ]
+        os: [ "rockylinux:9-minimal", "rockylinux:8-minimal", "redhat/ubi9-minimal:latest", "tencentos/tencentos4-minimal:latest", "opencloudos/opencloudos9-minimal:latest" ]
     container:
       image: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,7 +106,7 @@ jobs:
     strategy:
       matrix:
         version: [ 20, 22, 24, 25, 26 ]
-        os: [ "fedora:41", "amazonlinux:2023", "rockylinux:9", "rockylinux:8", "redhat/ubi9:latest" ]
+        os: [ "fedora:41", "amazonlinux:2023", "rockylinux:9", "rockylinux:8", "redhat/ubi9:latest", "tencentos/tencentos4:latest" ]
     container:
       image: ${{ matrix.os }}
     defaults:
@@ -198,7 +198,7 @@ jobs:
     strategy:
       matrix:
         version: [ 20, 22, 24, 25, 26 ]
-        os: [ "rockylinux:9-minimal", "rockylinux:8-minimal", "redhat/ubi9-minimal:latest" ]
+        os: [ "rockylinux:9-minimal", "rockylinux:8-minimal", "redhat/ubi9-minimal:latest", "tencentos/tencentos4-minimal:latest", "opencloudos/opencloudos9-minimal:latest" ]
     container:
       image: ${{ matrix.os }}
     defaults:
@@ -207,8 +207,16 @@ jobs:
     steps:
       - name: install git
         run: |
-          microdnf update -y
-          microdnf install git -y
+          if command -v microdnf &>/dev/null; then
+            PM=microdnf
+          elif command -v dnf &>/dev/null; then
+            PM=dnf
+          else
+            PM=yum
+          fi
+          echo "PM=$PM" >> $GITHUB_ENV
+          $PM update -y
+          $PM install git -y
 
       - name: Checkout Repo
         uses: actions/checkout@v5
@@ -217,11 +225,11 @@ jobs:
         run: ./scripts/rpm/setup_${{ matrix.version }}.x
 
       - name: Audit Repository
-        run: microdnf repolist
+        run: ${{ env.PM }} repolist
 
       - name: Install Nodejs
         run: |
-          microdnf install nodejs -y
+          ${{ env.PM }} install nodejs -y
 
       - name: Validate Node Version
         run: |
@@ -271,8 +279,8 @@ jobs:
       - name: Install NSolid
         if: matrix.version != 25 && matrix.version != 26
         run: |
-          microdnf remove nodejs -y
-          microdnf install nsolid -y
+          ${{ env.PM }} remove nodejs -y
+          ${{ env.PM }} install nsolid -y
 
       - name: Validate NSolid Version
         if: matrix.version != 25 && matrix.version != 26

--- a/scripts/rpm/script_generator/base_script.sh
+++ b/scripts/rpm/script_generator/base_script.sh
@@ -33,7 +33,7 @@ command_exists() {
 
 # Check if we are on an RPM-based system
 if ! [ -f /etc/redhat-release ] \
-   && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
+  && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
   && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
   && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."

--- a/scripts/rpm/script_generator/base_script.sh
+++ b/scripts/rpm/script_generator/base_script.sh
@@ -32,7 +32,10 @@ command_exists() {
 }
 
 # Check if we are on an RPM-based system
-if ! [ -f /etc/redhat-release ] && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null; then
+if ! [ -f /etc/redhat-release ] \
+   && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
+  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 

--- a/scripts/rpm/setup_16.x
+++ b/scripts/rpm/setup_16.x
@@ -66,11 +66,11 @@ print_bold \
   Use the installation script that corresponds to the version of Node.js you
   wish to install. e.g.
   
-   * ${red}https://rpm.nodesource.com/setup_16.x — Node.js 16 \"Gallium\" ${bold}(deprecated)${normal}
-   * ${green}https://rpm.nodesource.com/setup_18.x — Node.js 18 \"Hydrogen\" (Maintenance)${normal}
-   * ${red}https://rpm.nodesource.com/setup_19.x — Node.js 19 \"Nineteen\" ${bold}(deprecated)${normal}
-   * ${bold}${green}https://rpm.nodesource.com/setup_20.x — Node.js 20 LTS \"Iron\" (recommended)${normal}
-   * ${green}https://rpm.nodesource.com/setup_21.x — Node.js 21 \"Iron\" (current)${normal}
+  * ${red}https://rpm.nodesource.com/setup_16.x - Node.js 16 \"Gallium\" ${bold}(deprecated)${normal}
+  * ${green}https://rpm.nodesource.com/setup_18.x - Node.js 18 \"Hydrogen\" (Maintenance)${normal}
+  * ${red}https://rpm.nodesource.com/setup_19.x - Node.js 19 \"Nineteen\" ${bold}(deprecated)${normal}
+  * ${bold}${green}https://rpm.nodesource.com/setup_20.x - Node.js 20 LTS \"Iron\" (recommended)${normal}
+  * ${green}https://rpm.nodesource.com/setup_21.x - Node.js 21 \"Iron\" (current)${normal}
    
 
 
@@ -104,7 +104,10 @@ command_exists() {
 }
 
 # Check if we are on an RPM-based system
-if ! [ -f /etc/redhat-release ] && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null; then
+if ! [ -f /etc/redhat-release ] \
+   && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
+  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 node_deprecation_warning

--- a/scripts/rpm/setup_16.x
+++ b/scripts/rpm/setup_16.x
@@ -106,8 +106,8 @@ command_exists() {
 # Check if we are on an RPM-based system
 if ! [ -f /etc/redhat-release ] \
    && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
-  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
-  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
+   && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+   && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 node_deprecation_warning

--- a/scripts/rpm/setup_18.x
+++ b/scripts/rpm/setup_18.x
@@ -60,8 +60,8 @@ command_exists() {
 # Check if we are on an RPM-based system
 if ! [ -f /etc/redhat-release ] \
    && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
-  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
-  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
+   && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+   && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 

--- a/scripts/rpm/setup_18.x
+++ b/scripts/rpm/setup_18.x
@@ -58,7 +58,10 @@ command_exists() {
 }
 
 # Check if we are on an RPM-based system
-if ! [ -f /etc/redhat-release ] && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null; then
+if ! [ -f /etc/redhat-release ] \
+   && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
+  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 

--- a/scripts/rpm/setup_20.x
+++ b/scripts/rpm/setup_20.x
@@ -32,7 +32,10 @@ command_exists() {
 }
 
 # Check if we are on an RPM-based system
-if ! [ -f /etc/redhat-release ] && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null; then
+if ! [ -f /etc/redhat-release ] \
+   && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
+  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 

--- a/scripts/rpm/setup_20.x
+++ b/scripts/rpm/setup_20.x
@@ -34,8 +34,8 @@ command_exists() {
 # Check if we are on an RPM-based system
 if ! [ -f /etc/redhat-release ] \
    && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
-  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
-  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
+   && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+   && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 

--- a/scripts/rpm/setup_21.x
+++ b/scripts/rpm/setup_21.x
@@ -32,7 +32,10 @@ command_exists() {
 }
 
 # Check if we are on an RPM-based system
-if ! [ -f /etc/redhat-release ] && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null; then
+if ! [ -f /etc/redhat-release ] \
+   && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
+  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 

--- a/scripts/rpm/setup_21.x
+++ b/scripts/rpm/setup_21.x
@@ -34,8 +34,8 @@ command_exists() {
 # Check if we are on an RPM-based system
 if ! [ -f /etc/redhat-release ] \
    && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
-  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
-  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
+   && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+   && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 

--- a/scripts/rpm/setup_22.x
+++ b/scripts/rpm/setup_22.x
@@ -32,7 +32,10 @@ command_exists() {
 }
 
 # Check if we are on an RPM-based system
-if ! [ -f /etc/redhat-release ] && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null; then
+if ! [ -f /etc/redhat-release ] \
+   && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
+  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 

--- a/scripts/rpm/setup_22.x
+++ b/scripts/rpm/setup_22.x
@@ -34,8 +34,8 @@ command_exists() {
 # Check if we are on an RPM-based system
 if ! [ -f /etc/redhat-release ] \
    && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
-  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
-  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
+   && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+   && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 

--- a/scripts/rpm/setup_23.x
+++ b/scripts/rpm/setup_23.x
@@ -32,7 +32,10 @@ command_exists() {
 }
 
 # Check if we are on an RPM-based system
-if ! [ -f /etc/redhat-release ] && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null; then
+if ! [ -f /etc/redhat-release ] \
+   && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
+  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 

--- a/scripts/rpm/setup_23.x
+++ b/scripts/rpm/setup_23.x
@@ -34,8 +34,8 @@ command_exists() {
 # Check if we are on an RPM-based system
 if ! [ -f /etc/redhat-release ] \
    && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
-  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
-  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
+   && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+   && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 

--- a/scripts/rpm/setup_24.x
+++ b/scripts/rpm/setup_24.x
@@ -32,7 +32,10 @@ command_exists() {
 }
 
 # Check if we are on an RPM-based system
-if ! [ -f /etc/redhat-release ] && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null; then
+if ! [ -f /etc/redhat-release ] \
+   && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
+  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 

--- a/scripts/rpm/setup_24.x
+++ b/scripts/rpm/setup_24.x
@@ -34,8 +34,8 @@ command_exists() {
 # Check if we are on an RPM-based system
 if ! [ -f /etc/redhat-release ] \
    && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
-  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
-  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
+   && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+   && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 

--- a/scripts/rpm/setup_25.x
+++ b/scripts/rpm/setup_25.x
@@ -32,7 +32,10 @@ command_exists() {
 }
 
 # Check if we are on an RPM-based system
-if ! [ -f /etc/redhat-release ] && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null; then
+if ! [ -f /etc/redhat-release ] \
+   && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
+  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 

--- a/scripts/rpm/setup_25.x
+++ b/scripts/rpm/setup_25.x
@@ -34,8 +34,8 @@ command_exists() {
 # Check if we are on an RPM-based system
 if ! [ -f /etc/redhat-release ] \
    && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
-  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
-  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
+   && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+   && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 

--- a/scripts/rpm/setup_26.x
+++ b/scripts/rpm/setup_26.x
@@ -32,7 +32,10 @@ command_exists() {
 }
 
 # Check if we are on an RPM-based system
-if ! [ -f /etc/redhat-release ] && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null; then
+if ! [ -f /etc/redhat-release ] \
+   && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
+   && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+   && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 

--- a/scripts/rpm/setup_current.x
+++ b/scripts/rpm/setup_current.x
@@ -32,7 +32,10 @@ command_exists() {
 }
 
 # Check if we are on an RPM-based system
-if ! [ -f /etc/redhat-release ] && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null; then
+if ! [ -f /etc/redhat-release ] \
+   && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
+  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 

--- a/scripts/rpm/setup_current.x
+++ b/scripts/rpm/setup_current.x
@@ -34,8 +34,8 @@ command_exists() {
 # Check if we are on an RPM-based system
 if ! [ -f /etc/redhat-release ] \
    && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
-  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
-  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
+   && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+   && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 

--- a/scripts/rpm/setup_lts.x
+++ b/scripts/rpm/setup_lts.x
@@ -32,7 +32,10 @@ command_exists() {
 }
 
 # Check if we are on an RPM-based system
-if ! [ -f /etc/redhat-release ] && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null; then
+if ! [ -f /etc/redhat-release ] \
+   && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
+  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 

--- a/scripts/rpm/setup_lts.x
+++ b/scripts/rpm/setup_lts.x
@@ -34,8 +34,8 @@ command_exists() {
 # Check if we are on an RPM-based system
 if ! [ -f /etc/redhat-release ] \
    && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null \
-  && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
-  && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
+   && ! grep -qi "TencentOS" /etc/system-release 2>/dev/null \
+   && ! grep -qi "OpenCloudOS" /etc/system-release 2>/dev/null; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 


### PR DESCRIPTION
OpenCloudOS is a derivative distribution of TencentOS, so the description in this article applies to both distributions.

TencentOS use rpm as package management, but it has not /etc/os-release, only has /etc/system-release and /os-release, so added a patch to support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced RPM-based OS detection in the Node.js setup scripts to properly recognize TencentOS and OpenCloudOS environments.
* **Documentation**
  * Refined the Node.js 16.x deprecation notice text formatting for better readability.
* **Chores**
  * Expanded RPM-related CI coverage to include TencentOS and OpenCloudOS containers.
  * Updated RPM-minimal CI to automatically select the available package manager (microdnf/dnf/yum) during installs and the NSolid setup/removal steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->