### PR TITLE
feat: Add TencentOS Server support in RPM system detection

### DIFF
--- a/scripts/rpm/script_generator/base_script.sh
+++ b/scripts/rpm/script_generator/base_script.sh
@@ -32,7 +32,26 @@ command_exists() {
 }
 
 # Check if we are on an RPM-based system
-if ! [ -f /etc/redhat-release ] && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null; then
+# Supports: RHEL, CentOS, Fedora, Amazon Linux, TencentOS, and other EL-compatible distros
+is_rpm_system=false
+if [ -f /etc/redhat-release ]; then
+    is_rpm_system=true
+elif grep -q "Amazon Linux" /etc/system-release 2>/dev/null; then
+    is_rpm_system=true
+elif [ -f /etc/os-release ]; then
+    . /etc/os-release
+    case "$ID" in
+        rhel|centos|fedora|rocky|alma|tencentos|openEuler|anolis)
+            is_rpm_system=true
+            ;;
+    esac
+    # Fallback: check PLATFORM_ID for EL-compatible distros (e.g., platform:el9)
+    if [ "$is_rpm_system" = false ] && echo "${PLATFORM_ID:-}" | grep -q "platform:el"; then
+        is_rpm_system=true
+    fi
+fi
+
+if [ "$is_rpm_system" = false ]; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 
@@ -130,3 +149,4 @@ elif command_exists microdnf; then
 else
     handle_error 1 "Neither yum, dnf nor microdnf package manager was found. Please update your system using your package manager."
 fi
+

--- a/scripts/rpm/script_generator/base_script.sh
+++ b/scripts/rpm/script_generator/base_script.sh
@@ -41,7 +41,7 @@ elif grep -q "Amazon Linux" /etc/system-release 2>/dev/null; then
 elif [ -f /etc/os-release ]; then
     . /etc/os-release
     case "$ID" in
-        rhel|centos|fedora|rocky|alma|tencentos|openEuler|anolis)
+        rhel|centos|fedora|rocky|alma|tencentos)
             is_rpm_system=true
             ;;
     esac

--- a/scripts/rpm/setup_22.x
+++ b/scripts/rpm/setup_22.x
@@ -32,7 +32,26 @@ command_exists() {
 }
 
 # Check if we are on an RPM-based system
-if ! [ -f /etc/redhat-release ] && ! grep -q "Amazon Linux" /etc/system-release 2>/dev/null; then
+# Supports: RHEL, CentOS, Fedora, Amazon Linux, TencentOS, and other EL-compatible distros
+is_rpm_system=false
+if [ -f /etc/redhat-release ]; then
+    is_rpm_system=true
+elif grep -q "Amazon Linux" /etc/system-release 2>/dev/null; then
+    is_rpm_system=true
+elif [ -f /etc/os-release ]; then
+    . /etc/os-release
+    case "$ID" in
+        rhel|centos|fedora|rocky|alma|tencentos|openEuler|anolis)
+            is_rpm_system=true
+            ;;
+    esac
+    # Fallback: check PLATFORM_ID for EL-compatible distros (e.g., platform:el9)
+    if [ "$is_rpm_system" = false ] && echo "${PLATFORM_ID:-}" | grep -q "platform:el"; then
+        is_rpm_system=true
+    fi
+fi
+
+if [ "$is_rpm_system" = false ]; then
     handle_error 1 "This script is intended for RPM-based systems. Please run it on an RPM-based system."
 fi
 
@@ -130,3 +149,4 @@ elif command_exists microdnf; then
 else
     handle_error 1 "Neither yum, dnf nor microdnf package manager was found. Please update your system using your package manager."
 fi
+

--- a/scripts/rpm/setup_22.x
+++ b/scripts/rpm/setup_22.x
@@ -41,7 +41,7 @@ elif grep -q "Amazon Linux" /etc/system-release 2>/dev/null; then
 elif [ -f /etc/os-release ]; then
     . /etc/os-release
     case "$ID" in
-        rhel|centos|fedora|rocky|alma|tencentos|openEuler|anolis)
+        rhel|centos|fedora|rocky|alma|tencentos)
             is_rpm_system=true
             ;;
     esac


### PR DESCRIPTION
## Summary

The current RPM distribution detection in `base_script.sh` and `setup_22.x` only checks for `/etc/redhat-release` and Amazon Linux. This causes the setup scripts to fail on **TencentOS Server**, a RHEL-based distribution maintained by Tencent Cloud that does not ship `/etc/redhat-release` by default.

## Changes

Replaced the single-check detection logic with a multi-layer approach:

1. **`/etc/redhat-release`** — existing check, kept as-is
2. **Amazon Linux** — existing check via `/etc/system-release`, kept as-is
3. **`/etc/os-release` ID field** — new: matches `tencentos` (along with existing rhel/centos/fedora/rocky/alma)
4. **`PLATFORM_ID` fallback** — new: matches `platform:el*` pattern for EL-compatible distros

## Files Modified

- `scripts/rpm/script_generator/base_script.sh` — template used to generate all setup scripts
- `scripts/rpm/setup_22.x` — the Node.js 22.x setup script

## TencentOS Server Info

- **OS Release**: `ID=tencentos`, `PLATFORM_ID="platform:el9"`
- **Package Manager**: dnf (yum compatible)
- **Ecosystem**: Fully RHEL/EL9 compatible
- **Note**: `/etc/redhat-release` is NOT present by default
- **Official site**: https://cloud.tencent.com/product/ts

## Testing

Verified that the detection logic correctly identifies TencentOS Server as an RPM-based system and allows the Node.js setup to proceed normally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened RPM-based Linux distribution detection across multiple platforms
  * Extended compatibility to include Rocky, Alma, and TencentOS; added explicit Amazon Linux recognition
  * Added broader Enterprise Linux variant detection (platform:el) to improve coverage
  * Improved overall system identification accuracy for RPM-based distributions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->