### PR TITLE
feat: move v20 to deprecated versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 20, 22, 24, 25, 26 ]
+        version: [ 22, 24, 25, 26 ]
         os: [ "ubuntu:24.04", "ubuntu:22.04", "debian:13", "debian:11" ]
     container:
       image: ${{ matrix.os }}
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 20, 22, 24, 25, 26 ]
+        version: [ 22, 24, 25, 26 ]
         os: [ "fedora:41", "amazonlinux:2023", "rockylinux:9", "rockylinux:8", "redhat/ubi9:latest" ]
     container:
       image: ${{ matrix.os }}
@@ -197,7 +197,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 20, 22, 24, 25, 26 ]
+        version: [ 22, 24, 25, 26 ]
         os: [ "rockylinux:9-minimal", "rockylinux:8-minimal", "redhat/ubi9-minimal:latest" ]
     container:
       image: ${{ matrix.os }}

--- a/.github/workflows/deprecated.yaml
+++ b/.github/workflows/deprecated.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 16, 18 ]
+        version: [ 16, 18, 20 ]
         os: [ "ubuntu:20.04", "debian:10" ]
     container:
       image: ${{ matrix.os }}
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 16, 18 ]
+        version: [ 16, 18, 20 ]
         os: [ "fedora:29", "amazonlinux:2023" ]
     container:
       image: ${{ matrix.os }}

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -253,7 +253,7 @@ apt install -y curl
       ```
    </details>
 
-**Node.js v20.x**:
+**Node.js v20.x** (deprecated — end-of-life, no longer actively supported):
 
 ##### Using Ubuntu (Node.js 20)
 
@@ -359,7 +359,7 @@ apt install -y curl
       ```
    </details>
 
-**Node.js v18.x**:
+**Node.js v18.x** (deprecated — end-of-life, no longer actively supported):
 
 ##### Using Ubuntu (Node.js 18)
 
@@ -840,7 +840,7 @@ yum install -y curl
    node -v
    ```
 
-**Node.js v20.x**
+**Node.js v20.x** (deprecated — end-of-life, no longer actively supported)
 
 ##### As root (Node.js 20)
 
@@ -946,7 +946,7 @@ yum install -y curl
       ```
    </details>
 
-**Node.js v18.x**
+**Node.js v18.x** (deprecated — end-of-life, no longer actively supported)
 
 ##### As root (Node.js 18)
 
@@ -1270,7 +1270,7 @@ _source: <https://nodejs.dev>_
 
 Q: Are the scripts deprecated?
 
-A: The scripts are deprecated for the versions of Node.js that are currently outdated. While the packages for these versions still exist, we no longer provide support for them. Our support is exclusively dedicated to the active Node.js versions, which, as of today, are 18, 20, and 21. Users utilizing these versions can confidently use our scripts, but we encourage those using older versions to upgrade for continued support and the best experience.
+A: The scripts are deprecated for the versions of Node.js that are currently outdated. While the packages for these versions still exist, we no longer provide support for them. Our support is exclusively dedicated to the active Node.js versions, which, as of today, are 22, 24, 25, and 26. Users utilizing these versions can confidently use our scripts, but we encourage those using older versions to upgrade for continued support and the best experience.
 
 ---
 

--- a/scripts/deb/script_generator/README.md
+++ b/scripts/deb/script_generator/README.md
@@ -4,9 +4,9 @@ This repository contains scripts for setting up different versions of Node.js on
 
 ## Modifying the Scripts
 
-Each script in this repository sets up a specific version of Node.js. The version is specified in the line `NODE_VERSION="XX.x"` in each script. To modify the version, simply replace `"XX.x"` with the desired version, e.g., `"18.x"`.
+Each script in this repository sets up a specific version of Node.js. The version is specified in the line `NODE_VERSION="XX.x"` in each script. To modify the version, simply replace `"XX.x"` with the desired version, e.g., `"24.x"`.
 
-For example, to modify the `setup_18.x` script to install Node.js version 20.x instead, you would change the line to `NODE_VERSION="20.x"`.
+For example, to modify the `setup_24.x` script to install Node.js version 26.x instead, you would change the line to `NODE_VERSION="26.x"`.
 
 ## Running the Scripts
 
@@ -16,7 +16,7 @@ To run a script, navigate to the directory containing the script and run the fol
 sudo bash setup_XX.x
 ```
 
-Replace `XX.x` with the version number of the script you want to run. For example, to run the `setup_18.x` script, you would use the command `sudo bash setup_18.x`.
+Replace `XX.x` with the version number of the script you want to run. For example, to run the `setup_24.x` script, you would use the command `sudo bash setup_24.x`.
 
 ## How It Works
 
@@ -26,7 +26,7 @@ Each script in this repository performs the following steps:
 2. Configures the NodeSource Node.js DEB repository for the specified version of Node.js.
 3. Logs a message indicating that the repository is configured and updated, and instructs the user to run `apt install nodejs -y` to complete the installation.
 
-The `setup_current` and `setup_latest` scripts are special scripts that install the current and latest versions of Node.js, respectively. The current version is 20.x and the latest version is 21.x.
+The `setup_lts` and `setup_current` scripts are special scripts that install the LTS and current versions of Node.js, respectively. The LTS version is 24.x and the current version is 26.x.
 
 ## Updating the Scripts
 
@@ -36,7 +36,7 @@ If you make a change to the base script, you can regenerate all the version-spec
 bash generator.sh
 ```
 
-This script iterates over a list of versions (currently 18.x, 20.x, and 21.x), and creates a new script for each version with the updated base script. It also creates setup_current and setup_latest scripts for the current and latest versions of Node.js, respectively.
+This script iterates over a list of versions (currently 22.x, 24.x, 25.x, and 26.x), and creates a new script for each version with the updated base script. It also creates setup_lts and setup_current scripts for the LTS and current versions of Node.js, respectively.
 
 ## Deploying the Scripts
 

--- a/scripts/deb/script_generator/generator.sh
+++ b/scripts/deb/script_generator/generator.sh
@@ -25,7 +25,7 @@ if [ ! -f "$base_script" ]; then
 fi
 
 # List of versions
-versions=("20" "22" "24" "25" "26")
+versions=("22" "24" "25" "26")
 
 # Iterate over the versions and create scripts
 for version in "${versions[@]}"; do

--- a/scripts/rpm/script_generator/README.md
+++ b/scripts/rpm/script_generator/README.md
@@ -4,9 +4,9 @@ This repository contains scripts for setting up different versions of Node.js on
 
 ## Modifying the Scripts
 
-Each script in this repository sets up a specific version of Node.js. The version is specified in the line `NODE_VERSION="XX.x"` in each script. To modify the version, simply replace `"XX.x"` with the desired version, e.g., `"18.x"`.
+Each script in this repository sets up a specific version of Node.js. The version is specified in the line `NODE_VERSION="XX.x"` in each script. To modify the version, simply replace `"XX.x"` with the desired version, e.g., `"24.x"`.
 
-For example, to modify the `setup_18.x` script to install Node.js version 20.x instead, you would change the line to `NODE_VERSION="20.x"`.
+For example, to modify the `setup_24.x` script to install Node.js version 26.x instead, you would change the line to `NODE_VERSION="26.x"`.
 
 ## Running the Scripts
 
@@ -16,7 +16,7 @@ To run a script, navigate to the directory containing the script and run the fol
 sudo bash setup_XX.x
 ```
 
-Replace `XX.x` with the version number of the script you want to run. For example, to run the `setup_18.x` script, you would use the command `sudo bash setup_18.x`.
+Replace `XX.x` with the version number of the script you want to run. For example, to run the `setup_24.x` script, you would use the command `sudo bash setup_24.x`.
 
 ## How It Works
 
@@ -27,7 +27,7 @@ Each script in this repository performs the following steps:
 3. Checks if `dnf`, `yum` or `microdnf` is available and updates the system using the available package manager.
 4. Logs a message indicating that the repository is configured and updated, and instructs the user to run `dnf install nodejs -y`, `yum install nodejs -y` or `microdnf install nodejs -y` to complete the installation.
 
-The `setup_current` and `setup_latest` scripts are special scripts that install the current and latest versions of Node.js, respectively. The current version is 20.x and the latest version is 21.x.
+The `setup_lts` and `setup_current` scripts are special scripts that install the LTS and current versions of Node.js, respectively. The LTS version is 24.x and the current version is 26.x.
 
 ## Updating the Scripts
 
@@ -37,7 +37,7 @@ If you make a change to the base script, you can regenerate all the version-spec
 bash generator.sh
 ```
 
-This script iterates over a list of versions (currently 18.x, 20.x, and 21.x), and creates a new script for each version with the updated base script. It also creates setup_current and setup_latest scripts for the current and latest versions of Node.js, respectively.
+This script iterates over a list of versions (currently 23.x, 24.x, 25.x, and 26.x), and creates a new script for each version with the updated base script. It also creates setup_lts and setup_current scripts for the LTS and current versions of Node.js, respectively.
 
 ## Deploying the Scripts
 


### PR DESCRIPTION
## Summary
Moves Node.js v20 from the active/supported lane to deprecated (EOL), following the same pattern used for v18 in #1911.

## Changes
- **`.github/workflows/ci.yaml`**: remove `20` from the deb, rpm and rpm-minimal test matrices.
- **`.github/workflows/deprecated.yaml`**: add `20` to the deb and rpm deprecated matrices.
- **`scripts/deb/script_generator/generator.sh`**: drop `"20"` from the regenerated versions array (the existing `setup_20.x` scripts stay in place for current users, same as `setup_16.x`/`setup_18.x`).
- **`DEV_README.md`**: FAQ active versions updated to `22, 24, 25, 26`; v18 and v20 install sections flagged as deprecated/EOL.
- **`scripts/{deb,rpm}/script_generator/README.md`**: refresh stale LTS/current info (LTS 24.x, current 26.x), fix `setup_latest`→`setup_lts` naming, update the iterated version list and examples.

## Notes
- `setup_20.x` (deb & rpm) are intentionally kept on disk; they are no longer regenerated but still work for existing users.
- The deprecated workflow runs v20 on older OS images (`ubuntu:20.04`, `debian:10`, `fedora:29`, `amazonlinux:2023`) — worth watching in case those jobs need a newer OS matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Node.js version support documentation to reflect currently active versions (22, 24, 25, 26).
  * Marked Node.js v18 and v20 as deprecated/end-of-life.
  * Updated setup script generator documentation with examples for current supported versions.

* **Chores**
  * Updated CI/CD workflows to test against Node.js versions 22, 24, 25, and 26.
  * Updated script generators to produce setup scripts for current Node.js versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->